### PR TITLE
 Cleaning up common issues

### DIFF
--- a/DataProducts/AirQuality/Current_v1.0.json
+++ b/DataProducts/AirQuality/Current_v1.0.json
@@ -233,7 +233,7 @@
             "minimum": -90.0,
             "title": "Latitude",
             "description": "The latitude coordinate of the desired location.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "lon": {
             "type": "number",
@@ -241,12 +241,12 @@
             "minimum": -180.0,
             "title": "Longitude",
             "description": "The longitude coordinate of the desired location.",
-            "examples": [24.945831]
+            "examples": [24.945]
           }
         },
         "type": "object",
         "required": ["lat", "lon"],
-        "title": "CurrentAirQualityRequest"
+        "title": "Current air quality request"
       },
       "CurrentAirQualityResponse": {
         "properties": {
@@ -280,7 +280,7 @@
         },
         "type": "object",
         "required": ["airQualityIndex", "timestamp", "attribution"],
-        "title": "CurrentAirQualityResponse"
+        "title": "Current air quality response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/Cargo/Metrics_v0.1.json
+++ b/DataProducts/Cargo/Metrics_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo metrics",
     "description": "The key metrics of the transported cargo",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Cargo/Metrics_v0.1": {
@@ -238,7 +238,7 @@
             ],
             "title": "Weight (kg)",
             "description": "The weight of the cargo item in kilograms.",
-            "examples": [2000]
+            "examples": [2000.0]
           },
           "volume": {
             "anyOf": [
@@ -294,7 +294,7 @@
           }
         },
         "type": "object",
-        "title": "CargoItem"
+        "title": "Cargo item"
       },
       "CargoMetricsRequest": {
         "properties": {
@@ -308,7 +308,7 @@
         },
         "type": "object",
         "required": ["waybillNumber"],
-        "title": "CargoMetricsRequest"
+        "title": "Cargo metrics request"
       },
       "CargoMetricsResponse": {
         "properties": {
@@ -329,7 +329,7 @@
             ],
             "title": "Weight (kg)",
             "description": "The weight of the cargo within the delivery in kilograms.",
-            "examples": [20000]
+            "examples": [20000.0]
           },
           "volume": {
             "anyOf": [
@@ -342,7 +342,7 @@
             ],
             "title": "Volume (m^3)",
             "description": "The volume of the cargo within the delivery in cubic meters.",
-            "examples": [50]
+            "examples": [50.0]
           },
           "cargoUnits": {
             "anyOf": [
@@ -368,7 +368,7 @@
         },
         "type": "object",
         "required": ["cargoType", "cargoItems"],
-        "title": "CargoMetricsResponse"
+        "title": "Cargo metrics response"
       },
       "CargoType": {
         "type": "string",

--- a/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.1.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational performance",
     "description": "General operational status data of a mobile work machine operating in a port.",
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalPerformance_v0.1": {
@@ -256,7 +256,7 @@
           }
         },
         "type": "object",
-        "title": "CargoMoves"
+        "title": "Cargo moves"
       },
       "DataSourceError": {
         "properties": {
@@ -414,7 +414,7 @@
           }
         },
         "type": "object",
-        "title": "HoistMoves"
+        "title": "Hoist moves"
       },
       "NotFound": {
         "properties": {
@@ -477,7 +477,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -561,7 +561,7 @@
         },
         "type": "object",
         "required": ["runningHours", "distance"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.2.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational performance",
     "description": "General operational status data of a mobile work machine operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalPerformance_v0.2": {
@@ -255,7 +255,7 @@
           }
         },
         "type": "object",
-        "title": "CargoMoves"
+        "title": "Cargo moves"
       },
       "DataSourceError": {
         "properties": {
@@ -413,7 +413,7 @@
           }
         },
         "type": "object",
-        "title": "HoistMoves"
+        "title": "Hoist moves"
       },
       "NotFound": {
         "properties": {
@@ -476,7 +476,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -567,7 +567,7 @@
         },
         "type": "object",
         "required": ["runningHours"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational status",
     "description": "General operational status data of a cargo handling equipment operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalStatus_v0.2": {
@@ -359,7 +359,7 @@
             "minimum": -90.0,
             "title": "Latitude (°)",
             "description": "The latitude coordinate in decimal degrees.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "longitude": {
             "type": "number",
@@ -367,7 +367,7 @@
             "minimum": -180.0,
             "title": "Longitude (°)",
             "description": "The longitude coordinate in decimal degrees.",
-            "examples": [24.945831]
+            "examples": [24.945]
           }
         },
         "type": "object",
@@ -426,7 +426,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalStatusRequest"
+        "title": "Operational status request"
       },
       "OperationalStatusResponse": {
         "properties": {
@@ -523,7 +523,7 @@
         },
         "type": "object",
         "required": ["operationalState"],
-        "title": "OperationalStatusResponse"
+        "title": "Operational status response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/SustainabilityMetrics_v0.1.json
+++ b/DataProducts/CargoHandlingEquipment/SustainabilityMetrics_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment sustainability metrics",
     "description": "The power source consumption for the sustainability evaluation of the cargo handling equipment operations.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/CargoHandlingEquipment/SustainabilityMetrics_v0.1": {
@@ -448,7 +448,7 @@
         },
         "type": "object",
         "required": ["id", "startTime", "endTime"],
-        "title": "SustainabilityRequest"
+        "title": "Sustainability request"
       },
       "SustainabilityResponse": {
         "properties": {
@@ -496,7 +496,7 @@
           }
         },
         "type": "object",
-        "title": "SustainabilityResponse"
+        "title": "Sustainability response"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/Company/BasicInfo_v1.0.json
+++ b/DataProducts/Company/BasicInfo_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Basic information about a company",
     "description": "Legal information about a company such as company registration date.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Company/BasicInfo_v1.0": {
@@ -236,7 +236,7 @@
         },
         "type": "object",
         "required": ["companyId"],
-        "title": "BasicCompanyInfoRequest"
+        "title": "Basic company info request"
       },
       "BasicCompanyInfoResponse": {
         "properties": {
@@ -263,7 +263,7 @@
         },
         "type": "object",
         "required": ["name", "companyId", "companyForm", "registrationDate"],
-        "title": "BasicCompanyInfoResponse"
+        "title": "Basic company info response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/Company/Recommendation_v1.0.json
+++ b/DataProducts/Company/Recommendation_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Company recommendations based on keywords",
     "description": "Recommendation of companies based on provided keywords. Each result has a score.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Company/Recommendation_v1.0": {
@@ -412,7 +412,7 @@
             "type": "string",
             "title": "Company name",
             "description": "Name of the Company being recommended.",
-            "examples": ["Digital Living Oy"]
+            "examples": ["IOXIO Oy"]
           }
         },
         "type": "object",
@@ -430,7 +430,7 @@
         },
         "type": "object",
         "required": ["keywords"],
-        "title": "RecommendationRequest"
+        "title": "Recommendation request"
       },
       "RecommendationResponse": {
         "properties": {
@@ -445,7 +445,7 @@
         },
         "type": "object",
         "required": ["results"],
-        "title": "RecommendationResponse"
+        "title": "Recommendation response"
       },
       "ServiceUnavailable": {
         "properties": {

--- a/DataProducts/Company/Shareholders_v1.0.json
+++ b/DataProducts/Company/Shareholders_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "List of the shareholders of a company",
     "description": "Information about the shareholders of a company such as owners and shares quantity.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Company/Shareholders_v1.0": {
@@ -478,20 +478,20 @@
         },
         "type": "object",
         "required": ["seriesName", "votesPerShare", "totalShares"],
-        "title": "ShareSeries"
+        "title": "Share series"
       },
       "ShareholdersInfoRequest": {
         "properties": {
           "companyId": {
             "type": "string",
             "title": "Company ID",
-            "description": "The ID of the company, only supports Finnish business ID's.",
+            "description": "The ID of the company.",
             "examples": ["2464491-9"]
           }
         },
         "type": "object",
         "required": ["companyId"],
-        "title": "ShareholdersInfoRequest"
+        "title": "Shareholders info request"
       },
       "ShareholdersInfoResponse": {
         "properties": {
@@ -514,7 +514,7 @@
         },
         "type": "object",
         "required": ["shareSeries", "owners"],
-        "title": "ShareholdersInfoResponse"
+        "title": "Shareholders info response"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Battery/CarbonFootprint_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery carbon footprint",
     "description": "Carbon footprint of a battery as required by the European Commission's Battery Act (2023/1542).",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "paths": {
     "/DigitalProductPassport/Battery/CarbonFootprint_v0.1": {
@@ -270,7 +270,7 @@
           }
         },
         "type": "object",
-        "title": "CarbonFootprint"
+        "title": "Carbon footprint"
       },
       "CarbonFootprintRequest": {
         "properties": {
@@ -284,14 +284,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["660e8400-e29b-41d4-a716-446655440000"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "CarbonFootprintRequest"
+        "title": "Carbon footprint request"
       },
       "CarbonFootprintResponse": {
         "properties": {
@@ -362,7 +362,7 @@
           }
         },
         "type": "object",
-        "title": "CarbonFootprintResponse"
+        "title": "Carbon footprint response"
       },
       "DataSourceError": {
         "properties": {
@@ -593,7 +593,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingLocation": {
         "properties": {
@@ -608,7 +608,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the battery manufacturing location in Alpha-3 format.",
+            "description": "The country code of the battery manufacturing location in ISO 3166-1 alpha-3 format.",
             "examples": ["DEU"]
           },
           "city": {
@@ -627,7 +627,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingLocation"
+        "title": "Manufacturing location"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery Health Data",
     "description": "The health and status data of a battery as required by Battery Passport specification of the European Commission's Battery Act (2023/1542).",
-    "version": "0.1.6"
+    "version": "0.1.7"
   },
   "paths": {
     "/DigitalProductPassport/Battery/HealthData_v0.1": {
@@ -385,7 +385,7 @@
         },
         "type": "object",
         "required": ["eventDate"],
-        "title": "HarmfulEvent"
+        "title": "Harmful event"
       },
       "HealthDataRequest": {
         "properties": {
@@ -399,14 +399,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["660e8400-e29b-41d4-a716-446655440000"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "HealthDataRequest"
+        "title": "Health data request"
       },
       "HealthDataResponse": {
         "properties": {
@@ -434,7 +434,7 @@
               }
             ],
             "title": "Manufacturing Date",
-            "description": "The date of manufacture using month and year.",
+            "description": "The date of manufacture in ISO 8601 month format.",
             "examples": ["2023-07"]
           },
           "serviceInitiationDate": {
@@ -448,7 +448,7 @@
               }
             ],
             "title": "Service Initiation Date",
-            "description": "The date on which the battery was first commissioned.",
+            "description": "The date on which the battery was first commissioned in ISO 8601 month format.",
             "examples": ["2023-12"]
           },
           "originalPerformance": {
@@ -486,7 +486,7 @@
         },
         "type": "object",
         "required": ["harmfulEvents"],
-        "title": "HealthDataResponse"
+        "title": "Health data response"
       },
       "HealthState": {
         "properties": {
@@ -553,7 +553,7 @@
         },
         "type": "object",
         "required": ["operationDetails"],
-        "title": "HealthState"
+        "title": "Health state"
       },
       "NotFound": {
         "properties": {
@@ -620,7 +620,7 @@
           }
         },
         "type": "object",
-        "title": "OperationDetail"
+        "title": "Operation detail"
       },
       "OriginalPerformance": {
         "properties": {
@@ -692,7 +692,7 @@
           }
         },
         "type": "object",
-        "title": "OriginalPerformance"
+        "title": "Original performance"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Battery/HealthData_v0.2.json
+++ b/DataProducts/DigitalProductPassport/Battery/HealthData_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery health data",
     "description": "The health and status data of a battery as required by Battery Passport specification of the European Commission's Battery Act (2023/1542).",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/DigitalProductPassport/Battery/HealthData_v0.2": {
@@ -384,7 +384,7 @@
         },
         "type": "object",
         "required": ["eventDate"],
-        "title": "HarmfulEvent"
+        "title": "Harmful event"
       },
       "HealthDataRequest": {
         "properties": {
@@ -398,14 +398,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["660e8400-e29b-41d4-a716-446655440000"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "HealthDataRequest"
+        "title": "Health data request"
       },
       "HealthDataResponse": {
         "properties": {
@@ -433,7 +433,7 @@
               }
             ],
             "title": "Manufacturing date",
-            "description": "The date of manufacture using month and year.",
+            "description": "The date of manufacture in ISO 8601 month format.",
             "examples": ["2023-07"]
           },
           "serviceInitiationDate": {
@@ -447,7 +447,7 @@
               }
             ],
             "title": "Service initiation date",
-            "description": "The date on which the battery was first commissioned.",
+            "description": "The date on which the battery was first commissioned in ISO 8601 month format.",
             "examples": ["2023-12"]
           },
           "originalPerformance": {
@@ -485,7 +485,7 @@
         },
         "type": "object",
         "required": ["harmfulEvents"],
-        "title": "HealthDataResponse"
+        "title": "Health data response"
       },
       "HealthState": {
         "properties": {
@@ -591,7 +591,7 @@
         },
         "type": "object",
         "required": ["operationDetails"],
-        "title": "HealthState"
+        "title": "Health state"
       },
       "NotFound": {
         "properties": {
@@ -674,7 +674,7 @@
           }
         },
         "type": "object",
-        "title": "OperationDetail"
+        "title": "Operation detail"
       },
       "OriginalPerformance": {
         "properties": {
@@ -746,7 +746,7 @@
           }
         },
         "type": "object",
-        "title": "OriginalPerformance"
+        "title": "Original performance"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery manufacturing data sheet",
     "description": "Manufacturing data sheet as required by Battery Passport specification of the European Commission's Battery Act (2023/1542).",
-    "version": "0.1.6"
+    "version": "0.1.8"
   },
   "paths": {
     "/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1": {
@@ -351,7 +351,7 @@
           }
         },
         "type": "object",
-        "title": "ExpectedLifetime"
+        "title": "Expected lifetime"
       },
       "Forbidden": {
         "properties": {
@@ -450,7 +450,7 @@
         },
         "type": "object",
         "required": ["requirementConformity"],
-        "title": "LegalConformity"
+        "title": "Legal conformity"
       },
       "ManufacturerInformation": {
         "properties": {
@@ -521,7 +521,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturer's headquarters location in Alpha-3 format.",
+            "description": "The country code of the manufacturer's headquarters location in ISO 3166-1 alpha-3 format.",
             "examples": ["USA"]
           },
           "website": {
@@ -555,7 +555,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingDataSheetRequest": {
         "properties": {
@@ -569,14 +569,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["660e8400-e29b-41d4-a716-446655440000"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "ManufacturingDataSheetRequest"
+        "title": "Manufacturing data sheet request"
       },
       "ManufacturingDataSheetResponse": {
         "properties": {
@@ -655,7 +655,7 @@
               }
             ],
             "title": "Manufacturing date",
-            "description": "The date of manufacture using month and year.",
+            "description": "The date of manufacture in ISO 8601 month format.",
             "examples": ["2023-07"]
           },
           "weight": {
@@ -722,7 +722,7 @@
             ],
             "title": "Resistance (Ω)",
             "description": "The internal resistance of the battery pack in ohms.",
-            "examples": [0]
+            "examples": [0.1]
           },
           "roundTripEfficiency": {
             "anyOf": [
@@ -823,7 +823,7 @@
               }
             ],
             "title": "Warranty",
-            "description": "The date when the battery warranty expires.",
+            "description": "The date when the battery warranty expires in ISO 8601 month format.",
             "examples": ["2028-07"]
           },
           "extinguishingAgents": {
@@ -838,7 +838,7 @@
         },
         "type": "object",
         "required": ["recycledContent", "renewableContent", "extinguishingAgents"],
-        "title": "ManufacturingDataSheetResponse"
+        "title": "Manufacturing data sheet response"
       },
       "ManufacturingLocation": {
         "properties": {
@@ -853,7 +853,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the battery manufacturing location in Alpha-3 format.",
+            "description": "The country code of the battery manufacturing location in ISO 3166-1 alpha-3 format.",
             "examples": ["DEU"]
           },
           "city": {
@@ -872,7 +872,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingLocation"
+        "title": "Manufacturing location"
       },
       "MaterialComposition": {
         "properties": {
@@ -906,7 +906,7 @@
         },
         "type": "object",
         "required": ["chemistry", "hazardousSubstances", "criticalRawMaterials"],
-        "title": "MaterialComposition"
+        "title": "Material composition"
       },
       "NotFound": {
         "properties": {
@@ -982,7 +982,7 @@
           }
         },
         "type": "object",
-        "title": "RecycledContent"
+        "title": "Recycled content"
       },
       "RenewableContent": {
         "properties": {
@@ -1015,7 +1015,7 @@
           }
         },
         "type": "object",
-        "title": "RenewableContent"
+        "title": "Renewable content"
       },
       "RoundTripEfficiency": {
         "properties": {
@@ -1047,7 +1047,7 @@
           }
         },
         "type": "object",
-        "title": "RoundTripEfficiency"
+        "title": "Round trip efficiency"
       },
       "ServiceUnavailable": {
         "properties": {
@@ -1104,7 +1104,7 @@
           }
         },
         "type": "object",
-        "title": "TemperatureRange"
+        "title": "Temperature range"
       },
       "Unauthorized": {
         "properties": {
@@ -1199,7 +1199,7 @@
           }
         },
         "type": "object",
-        "title": "VoltageLevels"
+        "title": "Voltage levels"
       }
     }
   },

--- a/DataProducts/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.json
+++ b/DataProducts/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment data sheet",
     "description": "General as-built data of a cargo handling equipment operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2": {
@@ -326,7 +326,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "DataSheetRequest"
+        "title": "Data sheet request"
       },
       "DataSheetResponse": {
         "properties": {
@@ -360,7 +360,6 @@
           },
           "manufacturerInformation": {
             "$ref": "#/components/schemas/ManufacturerInformation",
-            "title": "Manufacturer information",
             "description": "The details of the manufacturer."
           },
           "powerSource": {
@@ -439,7 +438,7 @@
           "netVehicleMass",
           "maxLoadCapacity"
         ],
-        "title": "DataSheetResponse"
+        "title": "Data sheet response"
       },
       "DataSourceError": {
         "properties": {
@@ -579,7 +578,7 @@
             "maxLength": 250,
             "title": "Name",
             "description": "The registered trade name of the manufacturer company.",
-            "examples": ["Equipment Manufacturer Company X"]
+            "examples": ["Equipment Manufacturer Example LTD"]
           },
           "website": {
             "anyOf": [
@@ -599,7 +598,7 @@
         },
         "type": "object",
         "required": ["name"],
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/EnvironmentalFootprint_v0.1.json
+++ b/DataProducts/DigitalProductPassport/EnvironmentalFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Product environmental footprint",
     "description": "The environmental impact of the product manufacturing.",
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "paths": {
     "/DigitalProductPassport/EnvironmentalFootprint_v0.1": {
@@ -300,7 +300,7 @@
           }
         },
         "type": "object",
-        "title": "CarbonFootprint"
+        "title": "Carbon footprint"
       },
       "DataSourceError": {
         "properties": {
@@ -460,7 +460,7 @@
           }
         },
         "type": "object",
-        "title": "MaterialWaste"
+        "title": "Material waste"
       },
       "NotFound": {
         "properties": {
@@ -502,13 +502,12 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "ProductEnvironmentalFootprintRequest"
+        "title": "Product environmental footprint request"
       },
       "ProductEnvironmentalFootprintResponse": {
         "properties": {
           "carbonFootprint": {
             "$ref": "#/components/schemas/CarbonFootprint",
-            "title": "Carbon footprint",
             "description": "The details of the carbon footprint during production."
           },
           "materialWaste": {
@@ -526,7 +525,7 @@
         },
         "type": "object",
         "required": ["carbonFootprint"],
-        "title": "ProductEnvironmentalFootprintResponse"
+        "title": "Product environmental footprint response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/FoodArtifact/NutritionalValues_v0.1.json
+++ b/DataProducts/DigitalProductPassport/FoodArtifact/NutritionalValues_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Food Artifact Nutritional Values",
     "description": "Returns the nutritional values of a food product.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/FoodArtifact/NutritionalValues_v0.1": {
@@ -313,7 +313,7 @@
         },
         "type": "object",
         "required": ["energy", "calories"],
-        "title": "EnergyContent"
+        "title": "Energy content"
       },
       "FatContent": {
         "properties": {
@@ -427,7 +427,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "NutritionalValuesRequest"
+        "title": "Nutritional values request"
       },
       "NutritionalValuesResponse": {
         "properties": {
@@ -475,7 +475,7 @@
           "protein",
           "salt"
         ],
-        "title": "NutritionalValuesResponse"
+        "title": "Nutritional values response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/LogisticsEmissions_v0.1.json
+++ b/DataProducts/DigitalProductPassport/LogisticsEmissions_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Logistics Emissions",
     "description": "Returns the total emission per leg for an end-to-end shipment compliant with the European Union's count emissions reporting regulation.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/LogisticsEmissions_v0.1": {
@@ -346,7 +346,7 @@
           }
         },
         "type": "object",
-        "title": "EmissionsPerTCE"
+        "title": "Emissions per TCE"
       },
       "Forbidden": {
         "properties": {
@@ -438,7 +438,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "LogisticsEmissionsRequest"
+        "title": "Logistics emissions request"
       },
       "LogisticsEmissionsResponse": {
         "properties": {
@@ -466,7 +466,7 @@
         },
         "type": "object",
         "required": ["roadFreightEmissions", "seaFreightEmissions", "waybillNumber"],
-        "title": "LogisticsEmissionsResponse"
+        "title": "Logistics emissions response"
       },
       "NotFound": {
         "properties": {
@@ -631,7 +631,7 @@
             ],
             "title": "Emission Intensity",
             "description": "The GHG emission intensity of the road transport per transported tonne and kilometer in CO2e grams / tonne / km.",
-            "examples": [200]
+            "examples": [200.0]
           },
           "emissionsPerTce": {
             "items": {
@@ -644,7 +644,7 @@
         },
         "type": "object",
         "required": ["emissionsPerTce"],
-        "title": "RoadLeg"
+        "title": "Road leg"
       },
       "RoadLegFreightCondition": {
         "type": "string",
@@ -758,7 +758,7 @@
             ],
             "title": "Emission Intensity",
             "description": "The GHG emission intensity of the sea transport per transported tonne and kilometer in CO2e grams / tonne / km.",
-            "examples": [500]
+            "examples": [500.0]
           },
           "emissionsPerTce": {
             "items": {
@@ -771,7 +771,7 @@
         },
         "type": "object",
         "required": ["emissionsPerTce"],
-        "title": "SeaLeg"
+        "title": "Sea leg"
       },
       "SeaLegFreightCondition": {
         "type": "string",

--- a/DataProducts/DigitalProductPassport/Machine/ComponentSerialNumbers_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Machine/ComponentSerialNumbers_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Machine component serial numbers",
     "description": "List serial numbers of components in a machine.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/Machine/ComponentSerialNumbers_v0.1": {
@@ -370,7 +370,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "MachineSerialNumberRequest"
+        "title": "Machine serial number request"
       },
       "MachineSerialNumberResponse": {
         "properties": {
@@ -385,7 +385,7 @@
         },
         "type": "object",
         "required": ["serialNumbers"],
-        "title": "MachineSerialNumberResponse"
+        "title": "Machine serial number response"
       },
       "NotFound": {
         "properties": {
@@ -449,7 +449,7 @@
         },
         "type": "object",
         "required": ["name", "serial"],
-        "title": "SerialNumber"
+        "title": "Serial number"
       },
       "ServiceUnavailable": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Machine/QualityMetrics_v0.2.json
+++ b/DataProducts/DigitalProductPassport/Machine/QualityMetrics_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Measured quality metrics of a machine",
     "description": "Quality monitoring data for machines, including product serial number and quality performance measures.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/DigitalProductPassport/Machine/QualityMetrics_v0.2": {
@@ -478,7 +478,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "QualityMetricsRequest"
+        "title": "Quality metrics request"
       },
       "QualityMetricsResponse": {
         "properties": {
@@ -493,7 +493,7 @@
         },
         "type": "object",
         "required": ["metrics"],
-        "title": "QualityMetricsResponse"
+        "title": "Quality metrics response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/MetalArtifact/DataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/MetalArtifact/DataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Data Sheet For Metal Artifacts",
     "description": "Returns the basic product information of a metal product.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/MetalArtifact/DataSheet_v0.1": {
@@ -314,7 +314,7 @@
           }
         },
         "type": "object",
-        "title": "EnStandardCertification"
+        "title": "EN Standard certification"
       },
       "Forbidden": {
         "properties": {
@@ -433,7 +433,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "MetalArtifactDataSheetRequest"
+        "title": "Metal artifact data sheet request"
       },
       "MetalArtifactDataSheetResponse": {
         "properties": {
@@ -487,7 +487,7 @@
           "netWeight",
           "enStandardCertifications"
         ],
-        "title": "MetalArtifactDataSheetResponse"
+        "title": "Metal artifact data sheet response"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Drill Manufacturing Data Sheet",
     "description": "Manufacturing data sheet of a Mobile Drill Machine.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1": {
@@ -421,7 +421,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturer's headquarters location in Alpha-3 format.",
+            "description": "The country code of the manufacturer's headquarters location in ISO 3166-1 alpha-3 format.",
             "examples": ["SWE"]
           },
           "website": {
@@ -455,7 +455,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingDataSheetRequest": {
         "properties": {
@@ -469,14 +469,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["71b51878-8a00-11ee-b9d1-0242ac120002"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "ManufacturingDataSheetRequest"
+        "title": "Manufacturing data sheet request"
       },
       "ManufacturingDataSheetResponse": {
         "properties": {
@@ -616,7 +616,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingDataSheetResponse"
+        "title": "Manufacturing data sheet response"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.2.json
+++ b/DataProducts/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Drill Manufacturing Data Sheet",
     "description": "Manufacturing data sheet of a Mobile Drill Machine.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.2": {
@@ -376,7 +376,7 @@
           }
         },
         "type": "object",
-        "title": "ElectricMotors"
+        "title": "Electric motors"
       },
       "Forbidden": {
         "properties": {
@@ -502,7 +502,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturer's headquarters location in Alpha-3 format.",
+            "description": "The country code of the manufacturer's headquarters location in ISO 3166-1 alpha-3 format.",
             "examples": ["SWE"]
           },
           "website": {
@@ -536,7 +536,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingDataSheetRequest": {
         "properties": {
@@ -550,14 +550,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["71b51878-8a00-11ee-b9d1-0242ac120002"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "ManufacturingDataSheetRequest"
+        "title": "Manufacturing data sheet request"
       },
       "ManufacturingDataSheetResponse": {
         "properties": {
@@ -709,7 +709,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingDataSheetResponse"
+        "title": "Manufacturing data sheet response"
       },
       "NotFound": {
         "properties": {
@@ -766,7 +766,7 @@
         },
         "type": "object",
         "required": ["electricMotors"],
-        "title": "PowerSystem"
+        "title": "Power system"
       },
       "PowerSystemType": {
         "type": "string",

--- a/DataProducts/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.json
+++ b/DataProducts/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Mobile Work Machine Environmental Footprint",
     "description": "Carbon Footprint of a Mobile Work Machine.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1": {
@@ -270,7 +270,7 @@
           }
         },
         "type": "object",
-        "title": "CarbonFootprint"
+        "title": "Carbon footprint"
       },
       "DataSheetRequest": {
         "properties": {
@@ -284,14 +284,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["71b51878-8a00-11ee-b9d1-0242ac120002"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "DataSheetRequest"
+        "title": "Data sheet request"
       },
       "DataSheetResponse": {
         "properties": {
@@ -315,7 +315,7 @@
         },
         "type": "object",
         "required": ["carbonFootprint"],
-        "title": "DataSheetResponse"
+        "title": "Data sheet response"
       },
       "DataSourceError": {
         "properties": {
@@ -475,7 +475,7 @@
           }
         },
         "type": "object",
-        "title": "MaterialWaste"
+        "title": "Material waste"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/MobileWorkMachine/StraddleCarrier/OperationsData_v0.1.json
+++ b/DataProducts/DigitalProductPassport/MobileWorkMachine/StraddleCarrier/OperationsData_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Straddle carrier operations data",
     "description": "Operations data of a straddle carrier to retrieve fuel use, electricity use and distance driven",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/MobileWorkMachine/StraddleCarrier/OperationsData_v0.1": {
@@ -383,14 +383,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product",
             "examples": ["faf1e386-6a07-4f89-bdbe-b0a6a6241c69"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "OperationsDataRequest"
+        "title": "Operations data request"
       },
       "OperationsDataResponse": {
         "properties": {
@@ -415,7 +415,7 @@
         },
         "type": "object",
         "required": ["fuelUse", "electricityUse", "distance"],
-        "title": "OperationsDataResponse"
+        "title": "Operations data response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Product/CarbonFootprint_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Product/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Product carbon footprint",
     "description": "The carbon footprint of manufacturing a product.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Product/CarbonFootprint_v0.1": {

--- a/DataProducts/DigitalProductPassport/Product/FIBC/ProductDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Product/FIBC/ProductDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "FIBC Product data sheet",
     "description": "Product data sheet for FIBC bulk bags.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Product/FIBC/ProductDataSheet_v0.1": {
@@ -299,7 +299,7 @@
             ],
             "title": "Diameter (cm)",
             "description": "Diameter of the bottom part, in centimeters.",
-            "examples": [60]
+            "examples": [60.0]
           },
           "length": {
             "anyOf": [
@@ -312,7 +312,7 @@
             ],
             "title": "Length (cm)",
             "description": "Length of the bottom part, in centimeters.",
-            "examples": [60]
+            "examples": [60.0]
           },
           "coatingApplied": {
             "anyOf": [
@@ -605,7 +605,7 @@
             ],
             "title": "Thickness (µm)",
             "description": "Thickness of the liner, microns.",
-            "examples": [100]
+            "examples": [100.0]
           },
           "color": {
             "anyOf": [
@@ -652,7 +652,7 @@
             ],
             "title": "Height (cm)",
             "description": "Height of the loops, in centimeters.",
-            "examples": [30]
+            "examples": [30.0]
           },
           "color": {
             "anyOf": [
@@ -757,7 +757,7 @@
               }
             ],
             "title": "Production country",
-            "description": "Country where the product was produced, in ISO 3166-1 alpha-3.",
+            "description": "Country where the product was produced, in ISO 3166-1 alpha-3 format.",
             "examples": ["IND"]
           },
           "safetyFactor": {
@@ -786,7 +786,7 @@
         },
         "type": "object",
         "required": ["complianceCertifications"],
-        "title": "ManufacturingInformation"
+        "title": "Manufacturing information"
       },
       "NotFound": {
         "properties": {
@@ -949,7 +949,6 @@
           },
           "manufacturingInformation": {
             "$ref": "#/components/schemas/ManufacturingInformation",
-            "title": "Manufacturing information",
             "description": "The manufacturing details of the bag."
           },
           "dimensions": {
@@ -1119,7 +1118,7 @@
             ],
             "title": "Diameter (cm)",
             "description": "Diameter of the top spout, in centimeters.",
-            "examples": [40]
+            "examples": [40.0]
           },
           "length": {
             "anyOf": [
@@ -1132,7 +1131,7 @@
             ],
             "title": "Length (cm)",
             "description": "Length of the top spout, in centimeters.",
-            "examples": [50]
+            "examples": [50.0]
           },
           "coatingApplied": {
             "anyOf": [
@@ -1163,7 +1162,7 @@
           }
         },
         "type": "object",
-        "title": "TopSpout"
+        "title": "Top spout"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Product/FIBC/SustainabilityDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Product/FIBC/SustainabilityDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "FIBC sustainability data sheet",
     "description": "Basic sustainability data sheet for FIBC bulk bags.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Product/FIBC/SustainabilityDataSheet_v0.1": {
@@ -389,7 +389,7 @@
           }
         },
         "type": "object",
-        "title": "ProcessingEmissions"
+        "title": "Processing emissions"
       },
       "RateLimitExceeded": {
         "properties": {
@@ -430,7 +430,7 @@
           }
         },
         "type": "object",
-        "title": "RawMaterialEmissions"
+        "title": "Raw material emissions"
       },
       "Request": {
         "properties": {
@@ -466,21 +466,18 @@
             ],
             "title": "Carbon footprint (kg of CO2e)",
             "description": "Manufacturing carbon footprint of the bag, kilograms of CO2e.",
-            "examples": [4]
+            "examples": [4.0]
           },
           "rawMaterialEmissions": {
             "$ref": "#/components/schemas/RawMaterialEmissions",
-            "title": "Raw material emissions",
             "description": "Details of emissions from the raw material of the bag."
           },
           "processingEmissions": {
             "$ref": "#/components/schemas/ProcessingEmissions",
-            "title": "Processing emissions",
             "description": "Details of emissions from the processing and manufacturing of the bag."
           },
           "transportEmissions": {
             "$ref": "#/components/schemas/TransportEmissions",
-            "title": "Transport emissions",
             "description": "Details of the emissions from the transportation of the bag."
           },
           "circularityRate": {
@@ -494,7 +491,7 @@
             ],
             "title": "Circularity rate (%)",
             "description": "The percentage of the FIBC bag made from recycled materials.",
-            "examples": [30],
+            "examples": [30.0],
             "gte": 0,
             "lte": 100
           },
@@ -586,7 +583,7 @@
             ],
             "title": "Transport length (km)",
             "description": "Length of the upstream transport, from manufacturer to customer in kilometers.",
-            "examples": [350]
+            "examples": [350.0]
           },
           "fuelType": {
             "anyOf": [
@@ -617,7 +614,7 @@
           }
         },
         "type": "object",
-        "title": "TransportEmissions"
+        "title": "Transport emissions"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Product/GrainPassport_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Product/GrainPassport_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Grain Passport",
     "description": "Digital Product Passport for one shipment of grains.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/Product/GrainPassport_v0.1": {
@@ -374,7 +374,7 @@
               }
             ],
             "title": "Country",
-            "description": "Country of the producing farm in ISO 3166-1 alpha-3.",
+            "description": "Country of the producing farm in ISO 3166-1 alpha-3 format.",
             "examples": ["FIN"]
           },
           "processingEquipment": {
@@ -435,7 +435,7 @@
           "growthRegulatorDetails",
           "signature"
         ],
-        "title": "FarmerInformation"
+        "title": "Farmer information"
       },
       "Forbidden": {
         "properties": {
@@ -492,7 +492,7 @@
               }
             ],
             "title": "Growth regulator date",
-            "description": "Date of growth regulator application.",
+            "description": "Date of growth regulator application in ISO 8601 format.",
             "examples": ["2024-04-15"]
           },
           "growthRegulatorType": {
@@ -511,7 +511,7 @@
           }
         },
         "type": "object",
-        "title": "GrowthRegulatorDetails"
+        "title": "Growth regulator details"
       },
       "HTTPValidationError": {
         "properties": {
@@ -659,7 +659,7 @@
               }
             ],
             "title": "Country",
-            "description": "Recipient country in ISO 3166-1 alpha-3.",
+            "description": "Recipient country in ISO 3166-1 alpha-3 format.",
             "examples": ["FIN"]
           },
           "contractNumber": {
@@ -707,7 +707,7 @@
         },
         "type": "object",
         "required": ["company"],
-        "title": "RecipientInformation"
+        "title": "Recipient information"
       },
       "Request": {
         "properties": {
@@ -743,7 +743,7 @@
             "type": "string",
             "format": "date",
             "title": "Creation date",
-            "description": "Grain passport creation date.",
+            "description": "Grain passport creation date in ISO 8601 format.",
             "examples": ["2025-02-20"]
           },
           "grainType": {
@@ -763,7 +763,7 @@
           "harvestYear": {
             "type": "integer",
             "title": "Harvest year",
-            "description": "Year of harvesting.",
+            "description": "Year of harvesting in YYYY format.",
             "examples": [2024],
             "gte": 1900,
             "lte": 2500
@@ -882,7 +882,7 @@
             ],
             "title": "Shipment weight (kg)",
             "description": "Weight of the shipment in kg.",
-            "examples": [28500]
+            "examples": [28500.0]
           },
           "loadingTime": {
             "anyOf": [
@@ -923,7 +923,7 @@
               }
             ],
             "title": "Previous content date",
-            "description": "Date of the previous transportation with the truck in question, in RFC 3339 format.",
+            "description": "Date of the previous transportation with the truck in question, in ISO 8601 format.",
             "examples": ["2025-02-20"]
           },
           "previousContent": {
@@ -957,7 +957,7 @@
         },
         "type": "object",
         "required": ["company"],
-        "title": "TransportInformation"
+        "title": "Transport information"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/RockDrill/DataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/RockDrill/DataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Rock drill data sheet",
     "description": "General as-built data of a rock drill.",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "paths": {
     "/DigitalProductPassport/RockDrill/DataSheet_v0.1": {
@@ -244,7 +244,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "DataSheetRequest"
+        "title": "Data sheet request"
       },
       "DataSheetResponse": {
         "properties": {
@@ -297,7 +297,7 @@
             ],
             "title": "Minimum hole diameter (mm)",
             "description": "The minimum diameter of the drilling hole in millimeters.",
-            "examples": [76]
+            "examples": [76.0]
           },
           "maximumHoleDiameter": {
             "anyOf": [
@@ -310,7 +310,7 @@
             ],
             "title": "Maximum hole diameter (mm)",
             "description": "The maximum diameter of the drilling hole in millimeters.",
-            "examples": [127]
+            "examples": [127.0]
           },
           "weight": {
             "anyOf": [
@@ -323,7 +323,7 @@
             ],
             "title": "Weight (kg)",
             "description": "The net weight of the product in kilograms.",
-            "examples": [200]
+            "examples": [200.0]
           },
           "percussionRate": {
             "anyOf": [
@@ -336,7 +336,7 @@
             ],
             "title": "Percussion rate (Hz)",
             "description": "The frequency at which drill percussive action occurs in hertz.",
-            "examples": [50]
+            "examples": [50.0]
           },
           "drillingPower": {
             "anyOf": [
@@ -349,7 +349,7 @@
             ],
             "title": "Drilling power (kW)",
             "description": "The maximum drilling power in kilowatts.",
-            "examples": [160]
+            "examples": [160.0]
           },
           "referenceDataSheet": {
             "anyOf": [
@@ -398,7 +398,7 @@
           }
         },
         "type": "object",
-        "title": "DataSheetResponse"
+        "title": "Data sheet response"
       },
       "DataSourceError": {
         "properties": {
@@ -595,7 +595,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturer's headquarters location in Alpha-3 format.",
+            "description": "The country code of the manufacturer's headquarters location in ISO 3166-1 alpha-3 format.",
             "examples": ["SWE"]
           },
           "website": {
@@ -629,7 +629,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingLocation": {
         "properties": {
@@ -644,7 +644,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturing location in Alpha-3 format.",
+            "description": "The country code of the manufacturing location in ISO 3166-1 alpha-3 format.",
             "examples": ["DEU"]
           },
           "city": {
@@ -663,7 +663,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingLocation"
+        "title": "Manufacturing location"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/RockDrill/Piston/MaterialCertificate_v0.2.json
+++ b/DataProducts/DigitalProductPassport/RockDrill/Piston/MaterialCertificate_v0.2.json
@@ -381,7 +381,7 @@
         },
         "type": "object",
         "required": ["inspectionName", "inspectionDescription", "standardsCompliance"],
-        "title": "InspectionConformity"
+        "title": "Inspection conformity"
       },
       "MaterialCertificateRequest": {
         "properties": {
@@ -402,7 +402,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "MaterialCertificateRequest"
+        "title": "Material certificate request"
       },
       "MaterialCertificateResponse": {
         "properties": {
@@ -460,7 +460,7 @@
         },
         "type": "object",
         "required": ["castNumber", "orderNumber", "inspectionConformity"],
-        "title": "MaterialCertificateResponse"
+        "title": "Material certificate response"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment Bill of Materials",
     "description": "Details of the garment's bill of materials.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1": {
@@ -283,7 +283,7 @@
           }
         },
         "type": "object",
-        "title": "ColorInformation"
+        "title": "Color information"
       },
       "ColorScheme": {
         "type": "string",
@@ -298,7 +298,7 @@
             "minLength": 0,
             "title": "Name",
             "description": "The name of the component in the garment.",
-            "examples": ["zipper xyz / fabric silk xyz"]
+            "examples": ["zipper", "fabric silk"]
           },
           "type": {
             "$ref": "#/components/schemas/ComponentType",
@@ -484,7 +484,7 @@
             "type": "number",
             "title": "Share (%)",
             "description": "The percentage of material content in the component, expressed as a percentage by weight.",
-            "examples": [50],
+            "examples": [50.0],
             "gte": 0,
             "lte": 100
           },
@@ -499,7 +499,7 @@
             ],
             "title": "Recycling rate (%)",
             "description": "The amount of recycled content in the material substance, expressed as a percentage by weight.",
-            "examples": [50],
+            "examples": [50.0],
             "gte": 0,
             "lte": 100
           }

--- a/DataProducts/DigitalProductPassport/Textile/Garment/MaintenanceLog_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/MaintenanceLog_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment maintenance log",
     "description": "Details of the garment's care, repair and incidents.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/MaintenanceLog_v0.1": {
@@ -309,7 +309,7 @@
               }
             ],
             "title": "Event date",
-            "description": "The date of the event.",
+            "description": "The date of the event in ISO 8601 format.",
             "examples": ["2024-02-10"]
           },
           "eventDescription": {
@@ -458,7 +458,7 @@
             "type": "string",
             "format": "date",
             "title": "Commissioning date",
-            "description": "The date when the garment was delivered to the customer.",
+            "description": "The date when the garment was delivered to the customer in ISO 8601 format.",
             "examples": ["2023-06-01"]
           },
           "washingCycles": {

--- a/DataProducts/DigitalProductPassport/Textile/Garment/ManufacturerInformation_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/ManufacturerInformation_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment manufacturer information",
     "description": "Details of the garment manufacturers and facilities.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/ManufacturerInformation_v0.1": {
@@ -363,7 +363,7 @@
             "type": "string",
             "format": "date",
             "title": "Manufacturing date",
-            "description": "The date of the garment was manufactured.",
+            "description": "The date of the garment was manufactured in ISO 8601 format.",
             "examples": ["2023-01-01"]
           },
           "manufacturerName": {
@@ -376,7 +376,6 @@
           },
           "manufacturingLocation": {
             "$ref": "#/components/schemas/ManufacturingLocation",
-            "title": "Manufacturing location",
             "description": "The details of the manufacturing location."
           },
           "facilityId": {
@@ -391,7 +390,7 @@
               }
             ],
             "title": "Facility ID",
-            "description": "The facility id of the manufacturing site in the GLN format.",
+            "description": "The facility ID of the manufacturing site in the GLN format.",
             "examples": ["1234567000004"]
           }
         },
@@ -410,7 +409,7 @@
             "type": "string",
             "pattern": "^[A-Z]{3}$",
             "title": "Country",
-            "description": "The country code of the manufacturing location in Alpha-3 format.",
+            "description": "The country code of the manufacturing location in ISO 3166-1 alpha-3 format.",
             "examples": ["POL"]
           },
           "city": {
@@ -431,7 +430,7 @@
         },
         "type": "object",
         "required": ["country"],
-        "title": "ManufacturingLocation"
+        "title": "Manufacturing location"
       },
       "ManufacturingPhase": {
         "type": "string",

--- a/DataProducts/DigitalProductPassport/Textile/Garment/MaterialDisclosureSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/MaterialDisclosureSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment material disclosure sheet",
     "description": "Public summary of the garment's material composition, recycled content and material level certifications.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/MaterialDisclosureSheet_v0.1": {
@@ -442,7 +442,7 @@
         },
         "type": "object",
         "required": ["certifications", "materials"],
-        "title": "MaterialInformation"
+        "title": "Material information"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Textile/Garment/ProductDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/ProductDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment product data sheet",
     "description": "General specifications of a garment.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/ProductDataSheet_v0.1": {
@@ -252,13 +252,12 @@
           },
           "companyIdentification": {
             "$ref": "#/components/schemas/CompanyIdentification",
-            "title": "Company identification",
             "description": "The identification of the company being responsible of the DPP."
           }
         },
         "type": "object",
         "required": ["name", "companyIdentification"],
-        "title": "BrandInformation"
+        "title": "Brand information"
       },
       "ColorInformation": {
         "properties": {
@@ -299,7 +298,7 @@
         },
         "type": "object",
         "required": ["colorName"],
-        "title": "ColorInformation"
+        "title": "Color information"
       },
       "ColorScheme": {
         "type": "string",
@@ -325,7 +324,7 @@
         },
         "type": "object",
         "required": ["identifierScheme", "identifier"],
-        "title": "CompanyIdentification"
+        "title": "Company identification"
       },
       "DataSourceError": {
         "properties": {
@@ -572,12 +571,10 @@
           },
           "brandInformation": {
             "$ref": "#/components/schemas/BrandInformation",
-            "title": "Brand information",
             "description": "The details of the brand selling the garment."
           },
           "sizeInformation": {
             "$ref": "#/components/schemas/SizeInformation",
-            "title": "Size information",
             "description": "The size information of the garment."
           },
           "gender": {
@@ -595,7 +592,6 @@
           },
           "colorInformation": {
             "$ref": "#/components/schemas/ColorInformation",
-            "title": "Color information",
             "description": "The color information of the garment main color."
           },
           "weight": {
@@ -721,7 +717,7 @@
           }
         },
         "type": "object",
-        "title": "SizeInformation"
+        "title": "Size information"
       },
       "SizingSystem": {
         "type": "string",

--- a/DataProducts/Energy/Battery/ChargingHistory_v1.0.json
+++ b/DataProducts/Energy/Battery/ChargingHistory_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Charging history of a battery",
     "description": "Charging history of a battery.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Energy/Battery/ChargingHistory_v1.0": {
@@ -255,7 +255,7 @@
         },
         "type": "object",
         "required": ["time", "operatingHours", "cycleCount", "maxCapacity"],
-        "title": "ChargingHistoryEntry"
+        "title": "Charging history entry"
       },
       "ChargingHistoryRequest": {
         "properties": {
@@ -311,7 +311,7 @@
         },
         "type": "object",
         "required": ["serialNumber"],
-        "title": "ChargingHistoryRequest"
+        "title": "Charging history request"
       },
       "ChargingHistoryResponse": {
         "properties": {
@@ -332,7 +332,7 @@
         },
         "type": "object",
         "required": ["batteryChargingHistory", "totalCount"],
-        "title": "ChargingHistoryResponse"
+        "title": "Charging history response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/Energy/Battery/ProductDataSheet_v1.0.json
+++ b/DataProducts/Energy/Battery/ProductDataSheet_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery product data sheet",
     "description": "Technical details of a battery such as capacity and voltage.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Energy/Battery/ProductDataSheet_v1.0": {
@@ -236,7 +236,7 @@
         },
         "type": "object",
         "required": ["productCode"],
-        "title": "BatteryDataRequest"
+        "title": "Battery data request"
       },
       "BatteryDataResponse": {
         "properties": {
@@ -337,13 +337,13 @@
             "title": "Standards Compliance",
             "examples": [
               [
-                "IEC 62061 SIL 2",
-                "ISO 13849 PL C",
-                "IEC 61508 SIL 2",
                 "UN 38.3",
-                "ECE R100",
                 "ECE R10",
-                "ISO 16750"
+                "ECE R100",
+                "ISO 13849 PL C",
+                "ISO 16750",
+                "IEC 61508 SIL 2",
+                "IEC 62061 SIL 2"
               ]
             ]
           }
@@ -369,7 +369,7 @@
           "maxCoolantPressure",
           "standardsCompliance"
         ],
-        "title": "BatteryDataResponse"
+        "title": "Battery data response"
       },
       "CellType": {
         "type": "string",
@@ -623,12 +623,12 @@
           "recommendedMax": {
             "type": "number",
             "title": "Maximum recommended operating temperature [°C]",
-            "examples": [35]
+            "examples": [35.0]
           }
         },
         "type": "object",
         "required": ["min", "max", "recommendedMin", "recommendedMax"],
-        "title": "OperatingTemperature"
+        "title": "Operating temperature"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Key/CreateAssignment_v1.0.json
+++ b/DataProducts/Key/CreateAssignment_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Create key assignment",
     "description": "Assign a key to have access to a specific lock.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Key/CreateAssignment_v1.0": {
@@ -245,12 +245,12 @@
           "sharedSecret": {
             "type": "string",
             "title": "Shared Secret",
-            "description": "Shared secret between the productizer and the system using it."
+            "description": "Shared secret between the data source and the system using it."
           }
         },
         "type": "object",
         "required": ["keyId", "lockId", "sharedSecret"],
-        "title": "CreateAssignmentRequest"
+        "title": "Create assignment request"
       },
       "CreateAssignmentResponse": {
         "properties": {
@@ -272,7 +272,7 @@
         },
         "type": "object",
         "required": ["keyId", "lockId"],
-        "title": "CreateAssignmentResponse"
+        "title": "Create assignment response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/Key/DeleteAssignment_v1.0.json
+++ b/DataProducts/Key/DeleteAssignment_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Delete key assignment",
     "description": "Remove a key from having access to a specific lock.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Key/DeleteAssignment_v1.0": {
@@ -289,12 +289,12 @@
           "sharedSecret": {
             "type": "string",
             "title": "Shared Secret",
-            "description": "Shared secret between the productizer and the system using it."
+            "description": "Shared secret between the data source and the system using it."
           }
         },
         "type": "object",
         "required": ["keyId", "lockId", "sharedSecret"],
-        "title": "DeleteAssignmentRequest"
+        "title": "Delete assignment request"
       },
       "DeleteAssignmentResponse": {
         "properties": {
@@ -316,7 +316,7 @@
         },
         "type": "object",
         "required": ["keyId", "lockId"],
-        "title": "DeleteAssignmentResponse"
+        "title": "Delete assignment response"
       },
       "DoesNotConformToDefinition": {
         "properties": {

--- a/DataProducts/Key/LockAssignmentExists_v1.0.json
+++ b/DataProducts/Key/LockAssignmentExists_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Check if lock assignment exists",
     "description": "Check if a key has access to a specific lock.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Key/LockAssignmentExists_v1.0": {
@@ -371,12 +371,12 @@
           "sharedSecret": {
             "type": "string",
             "title": "Shared Secret",
-            "description": "Shared secret between the productizer and the system using it."
+            "description": "Shared secret between the data source and the system using it."
           }
         },
         "type": "object",
         "required": ["keyId", "lockId", "sharedSecret"],
-        "title": "LockAssignmentExistsRequest"
+        "title": "Lock assignment exists request"
       },
       "LockAssignmentExistsResponse": {
         "properties": {
@@ -389,7 +389,7 @@
         },
         "type": "object",
         "required": ["exists"],
-        "title": "LockAssignmentExistsResponse"
+        "title": "Lock assignment exists response"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/Logistics/TransportChain/CarbonFootprint/Push_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/CarbonFootprint/Push_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total carbon footprint for a transport chain",
     "description": "Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/Logistics/TransportChain/CarbonFootprint/Push_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -486,7 +486,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Logistics/TransportChain/CarbonFootprint_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total carbon footprint for a transport chain",
     "description": "Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Logistics/TransportChain/CarbonFootprint_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -493,7 +493,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Monthly carbon footprint for logistics transport chains",
     "description": "Monthly logistics carbon footprint for a cargo owner compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -466,7 +466,7 @@
         },
         "type": "object",
         "required": ["origin", "destination", "calculationMethod", "carbonFootprint"],
-        "title": "MonthlyFootprint"
+        "title": "Monthly footprint"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/Logistics/Transportation/TotalEmissions_v0.1.json
+++ b/DataProducts/Logistics/Transportation/TotalEmissions_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total emissions for a transport chain",
     "description": "Total emissions for a transport chain compliant with GHG protocol Scope 3 transport emissions.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Logistics/Transportation/TotalEmissions_v0.1": {
@@ -370,7 +370,7 @@
             "type": "string",
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -479,7 +479,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Market/Electricity/Pricing/History_v0.1.json
+++ b/DataProducts/Market/Electricity/Pricing/History_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Electricity market price",
     "description": "Electricity price per MWh.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Market/Electricity/Pricing/History_v0.1": {
@@ -301,27 +301,27 @@
           "location": {
             "type": "string",
             "title": "Location",
-            "description": "E.g. the country in ISO 3166-1 alpha-3 or other location identifier.",
+            "description": "E.g. the country in ISO 3166-1 alpha-3 format or other location identifier.",
             "examples": ["FIN"]
           },
           "startTime": {
             "type": "string",
             "format": "date-time",
             "title": "Start time",
-            "description": "Start time of the requested time period, in RFC 3339.",
+            "description": "Start time of the requested time period, in RFC 3339 format.",
             "examples": ["2024-01-01T00:00:00+02:00"]
           },
           "endTime": {
             "type": "string",
             "format": "date-time",
             "title": "End time",
-            "description": "End time of the requested time period, in RFC 3339.",
+            "description": "End time of the requested time period, in RFC 3339 format.",
             "examples": ["2024-01-01T23:59:59+02:00"]
           }
         },
         "type": "object",
         "required": ["location", "startTime", "endTime"],
-        "title": "EnergyPriceRequest"
+        "title": "Energy price request"
       },
       "EnergyPriceResponse": {
         "properties": {
@@ -343,7 +343,7 @@
         },
         "type": "object",
         "required": ["currencyCode", "prices"],
-        "title": "EnergyPriceResponse"
+        "title": "Energy price response"
       },
       "Forbidden": {
         "properties": {
@@ -433,13 +433,13 @@
             "type": "string",
             "format": "date-time",
             "title": "Start time",
-            "description": "Start time of the pricing period, in RFC 3339.",
+            "description": "Start time of the pricing period, in RFC 3339 format.",
             "examples": ["2024-01-01T02:00:00+02:00"]
           }
         },
         "type": "object",
         "required": ["price", "startTime"],
-        "title": "PeriodPrice"
+        "title": "Period price"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Meteorology/Weather_v0.1.json
+++ b/DataProducts/Meteorology/Weather_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Weather in metric units",
     "description": "Weather information for a given location, either current weather prediction or historical weather observations, using metric units.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Meteorology/Weather_v0.1": {
@@ -473,7 +473,7 @@
             "minimum": -90.0,
             "title": "Latitude (°)",
             "description": "The latitude coordinate of the desired location in degrees.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "lon": {
             "type": "number",
@@ -481,7 +481,7 @@
             "minimum": -180.0,
             "title": "Longitude (°)",
             "description": "The longitude coordinate of the desired location in degrees.",
-            "examples": [24.945831]
+            "examples": [24.945]
           },
           "when": {
             "anyOf": [
@@ -500,7 +500,7 @@
         },
         "type": "object",
         "required": ["lat", "lon"],
-        "title": "WeatherRequest"
+        "title": "Weather request"
       },
       "WeatherResponse": {
         "properties": {
@@ -524,7 +524,7 @@
             ],
             "title": "Humidity (%)",
             "description": "Current relative air humidity percentage.",
-            "examples": [72]
+            "examples": [72.0]
           },
           "pressure": {
             "anyOf": [
@@ -538,7 +538,7 @@
             ],
             "title": "Pressure (hPa)",
             "description": "Current air pressure in hectopascals.",
-            "examples": [1007]
+            "examples": [1007.0]
           },
           "windSpeed": {
             "anyOf": [
@@ -602,7 +602,7 @@
         },
         "type": "object",
         "required": ["temperature"],
-        "title": "WeatherResponse"
+        "title": "Weather response"
       }
     }
   },

--- a/DataProducts/NSG/Agent/BasicInformation_v1.0.json
+++ b/DataProducts/NSG/Agent/BasicInformation_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NSG Agent information",
     "description": "In the Nordic Smart Government information exchange context the agent represents both registered organizations (\"companies\") and persons who are doing business without being registered organizations, usually as sole traders (sole proprietors). This data product definition returns basic information content for any agent.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/NSG/Agent/BasicInformation_v1.0": {
@@ -236,7 +236,7 @@
         },
         "type": "object",
         "required": ["nationalIdentifier"],
-        "title": "BasicInformationRequest"
+        "title": "Basic information request"
       },
       "BasicInformationResponse": {
         "properties": {
@@ -276,7 +276,7 @@
           "registrationDate",
           "registeredAddress"
         ],
-        "title": "BasicInformationResponse"
+        "title": "Basic information response"
       },
       "DataSourceError": {
         "properties": {
@@ -1005,13 +1005,13 @@
                 "type": "null"
               }
             ],
-            "title": "Address id",
+            "title": "Address ID",
             "description": "A globally unique identifier for each instance of an Address. The concept of adding a globally unique identifier for each instance of an address is a crucial part of the INSPIRE data spec. A number of EU countries have already implemented an ID (a UUID) in their Address Register, among them Denmark.",
             "examples": ["123e4567-e89b-12d3-a456-42661417400"]
           }
         },
         "type": "object",
-        "title": "RegisteredAddress"
+        "title": "Registered address"
       },
       "ServiceUnavailable": {
         "properties": {

--- a/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners_v1.0.json
+++ b/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Beneficial owners of a non-listed company",
     "description": "The list of beneficial owners of a non-listed company. The shareholders exceeding 25 % ownership.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners_v1.0": {
@@ -233,12 +233,12 @@
             "maxLength": 40,
             "title": "National identifier",
             "description": "The national identifier of the non-listed company issued by the trade register in any Nordic country.",
-            "examples": ["FIN: 2464491-9 / SWE: 5560125791 / NOR:  923609016"]
+            "examples": ["2464491-9", "5560125791", "923609016"]
           }
         },
         "type": "object",
         "required": ["nationalIdentifier"],
-        "title": "BeneficialOwnersRequest"
+        "title": "Beneficial owners request"
       },
       "BeneficialOwnersResponse": {
         "properties": {
@@ -261,7 +261,7 @@
         },
         "type": "object",
         "required": ["shareSeries", "shareholders"],
-        "title": "BeneficialOwnersResponse"
+        "title": "Beneficial owners response"
       },
       "DataSourceError": {
         "properties": {
@@ -471,7 +471,7 @@
         },
         "type": "object",
         "required": ["shareSeriesClass", "quantity"],
-        "title": "ShareOwnership"
+        "title": "Share ownership"
       },
       "ShareSeries": {
         "properties": {
@@ -497,7 +497,7 @@
         },
         "type": "object",
         "required": ["shareSeriesClass", "numberOfShares", "votesPerShare"],
-        "title": "ShareSeries"
+        "title": "Share series"
       },
       "Shareholder": {
         "properties": {
@@ -506,7 +506,7 @@
             "maxLength": 250,
             "title": "Name",
             "description": "The name of a shareholder of the company.",
-            "examples": ["Lars Lindberg | Company Ltd"]
+            "examples": ["Lars Lindberg", "Company Ltd"]
           },
           "shareOwnership": {
             "items": {

--- a/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write_v1.0.json
+++ b/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Establish a non-listed company",
     "description": "Create the initial set of data to establish a non-listed company.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write_v1.0": {
@@ -244,7 +244,7 @@
           }
         },
         "type": "object",
-        "title": "AuditorDetails"
+        "title": "Auditor details"
       },
       "BadGateway": {
         "properties": {
@@ -340,7 +340,7 @@
           "dateOfBirth",
           "nationality"
         ],
-        "title": "BoardMember"
+        "title": "Board member"
       },
       "BoardMemberRole": {
         "type": "string",
@@ -490,7 +490,7 @@
           }
         },
         "type": "object",
-        "title": "CompanyAddress"
+        "title": "Company address"
       },
       "CompanyDetails": {
         "properties": {
@@ -590,7 +590,7 @@
               }
             ],
             "title": "Country of residence",
-            "description": "The company's current country of the residence in the three character (Alpha-3) format if it already exists abroad.",
+            "description": "The company's current country of the residence in the ISO 3166-1 alpha-3 format if it already exists abroad.",
             "examples": ["USA"]
           }
         },
@@ -602,7 +602,7 @@
           "shareCapital",
           "capitalCurrency"
         ],
-        "title": "CompanyDetails"
+        "title": "Company details"
       },
       "DataSourceError": {
         "properties": {
@@ -683,7 +683,6 @@
           },
           "companyDetails": {
             "$ref": "#/components/schemas/CompanyDetails",
-            "title": "Company details",
             "description": "The details of the company being established."
           },
           "shareSeries": {
@@ -696,7 +695,6 @@
           },
           "companyAddress": {
             "$ref": "#/components/schemas/CompanyAddress",
-            "title": "Company address",
             "description": "The official address of the company."
           },
           "managingDirectors": {
@@ -715,7 +713,6 @@
           },
           "auditorDetails": {
             "$ref": "#/components/schemas/AuditorDetails",
-            "title": "Auditor details",
             "description": "The details of the company and person auditing the company."
           }
         },
@@ -729,7 +726,7 @@
           "boardMembers",
           "auditorDetails"
         ],
-        "title": "EstablishmentRequest"
+        "title": "Establishment request"
       },
       "EstablishmentResponse": {
         "properties": {
@@ -739,7 +736,6 @@
           },
           "companyDetails": {
             "$ref": "#/components/schemas/CompanyDetails",
-            "title": "Company details",
             "description": "The details of the company being established."
           },
           "shareSeries": {
@@ -752,7 +748,6 @@
           },
           "companyAddress": {
             "$ref": "#/components/schemas/CompanyAddress",
-            "title": "Company address",
             "description": "The official address of the company."
           },
           "managingDirectors": {
@@ -771,7 +766,6 @@
           },
           "auditorDetails": {
             "$ref": "#/components/schemas/AuditorDetails",
-            "title": "Auditor details",
             "description": "The details of the company and person auditing the company."
           }
         },
@@ -785,7 +779,7 @@
           "boardMembers",
           "auditorDetails"
         ],
-        "title": "EstablishmentResponse"
+        "title": "Establishment request"
       },
       "Forbidden": {
         "properties": {
@@ -2130,7 +2124,7 @@
           "dateOfBirth",
           "nationality"
         ],
-        "title": "ManagingDirector"
+        "title": "Managing director"
       },
       "ManagingDirectorRole": {
         "type": "string",
@@ -2201,7 +2195,7 @@
             "format": "email",
             "title": "Email",
             "description": "The person's contact email address.",
-            "examples": ["john.doe@test.fi"]
+            "examples": ["john.doe@example.com"]
           },
           "phoneNumber": {
             "type": "string",
@@ -2266,7 +2260,7 @@
         },
         "type": "object",
         "required": ["shareSeriesClass", "numberOfShares", "shareValue"],
-        "title": "ShareSeries"
+        "title": "Share series"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights_v1.0.json
+++ b/DataProducts/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Signatory rights of a non-listed company",
     "description": "The list of representation rights of a legal entity.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights_v1.0": {
@@ -882,7 +882,7 @@
           "dateOfBirth",
           "nationality"
         ],
-        "title": "SignatoryRights"
+        "title": "Signatory rights"
       },
       "SignatoryRightsRequest": {
         "properties": {
@@ -891,12 +891,12 @@
             "maxLength": 40,
             "title": "National identifier",
             "description": "The national identifier of the non-listed company issued by the trade register.",
-            "examples": ["FIN: 2464491-9 / SWE: 5560125791 / NOR: 923609016"]
+            "examples": ["2464491-9", "5560125791", "923609016"]
           }
         },
         "type": "object",
         "required": ["nationalIdentifier"],
-        "title": "SignatoryRightsRequest"
+        "title": "Signatory rights request"
       },
       "SignatoryRightsResponse": {
         "properties": {
@@ -911,7 +911,7 @@
         },
         "type": "object",
         "required": ["signatoryRights"],
-        "title": "SignatoryRightsResponse"
+        "title": "Signatory rights response"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/Person/Details_v1.0.json
+++ b/DataProducts/Person/Details_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person details",
     "description": "Details about a person such as home address.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Person/Details_v1.0": {
@@ -376,7 +376,7 @@
       "PersonDetailsRequest": {
         "properties": {},
         "type": "object",
-        "title": "PersonDetailsRequest"
+        "title": "Person details request"
       },
       "PersonDetailsResponse": {
         "properties": {
@@ -395,7 +395,7 @@
         },
         "type": "object",
         "required": ["name", "address"],
-        "title": "PersonDetailsResponse"
+        "title": "Person details response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Product/MachinedComponent/MeasurementReport_v0.1.json
+++ b/DataProducts/Product/MachinedComponent/MeasurementReport_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Machined component measurement report",
     "description": "The quality measurement report for a batch of machined components.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Product/MachinedComponent/MeasurementReport_v0.1": {
@@ -231,7 +231,7 @@
           "purchaseOrder": {
             "type": "string",
             "maxLength": 40,
-            "title": "Purchase order ",
+            "title": "Purchase order",
             "description": "The number of the purchase order related to the component.",
             "examples": ["12345"]
           },
@@ -252,7 +252,7 @@
         },
         "type": "object",
         "required": ["purchaseOrder", "componentName", "productionNumber"],
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "CustomerInformation": {
         "properties": {
@@ -261,7 +261,7 @@
             "maxLength": 250,
             "title": "Name",
             "description": "The name of the customer that has issued the component order.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "department": {
             "anyOf": [
@@ -275,12 +275,12 @@
             ],
             "title": "Department",
             "description": "The responsible department of the customer that has issued the component order.",
-            "examples": ["Department xyz"]
+            "examples": ["Department Name"]
           }
         },
         "type": "object",
         "required": ["name"],
-        "title": "CustomerInformation"
+        "title": "Customer information"
       },
       "DataSourceError": {
         "properties": {
@@ -448,7 +448,7 @@
         },
         "type": "object",
         "required": ["cmmSerialNumber"],
-        "title": "MeasurementEquipment"
+        "title": "Measurement equipment"
       },
       "MeasurementResult": {
         "properties": {
@@ -512,7 +512,7 @@
           "lowerTolerance",
           "deviation"
         ],
-        "title": "MeasurementResult"
+        "title": "Measurement result"
       },
       "MeasurementSetup": {
         "properties": {
@@ -615,7 +615,7 @@
           "measuredComponents",
           "measurementEquipment"
         ],
-        "title": "MeasurementSetup"
+        "title": "Measurement setup"
       },
       "NotFound": {
         "properties": {
@@ -678,17 +678,14 @@
         "properties": {
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "customerInformation": {
             "$ref": "#/components/schemas/CustomerInformation",
-            "title": "Customer information",
             "description": "The details of the customer issuing the order for the component."
           },
           "measurementSetup": {
             "$ref": "#/components/schemas/MeasurementSetup",
-            "title": "Measurement setup",
             "description": "The details describing the quality measurement setup."
           },
           "measurementResults": {

--- a/DataProducts/Product/Manufacturing/EnvironmentalFootprint_v1.0.json
+++ b/DataProducts/Product/Manufacturing/EnvironmentalFootprint_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Environmental footprint information for a product",
     "description": "Information about environmental footprint of a product in the manufacturing phase.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Product/Manufacturing/EnvironmentalFootprint_v1.0": {
@@ -307,7 +307,7 @@
         },
         "type": "object",
         "required": ["serialNumber"],
-        "title": "EnvironmentalFootprintRequest"
+        "title": "Environmental footprint request"
       },
       "EnvironmentalFootprintResponse": {
         "properties": {
@@ -326,7 +326,7 @@
         },
         "type": "object",
         "required": ["carbonEquivalent", "materialWaste"],
-        "title": "EnvironmentalFootprintResponse"
+        "title": "Environmental footprint response"
       },
       "Forbidden": {
         "properties": {

--- a/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
+++ b/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Metal component measurement report",
     "description": "The quality measurement report for metal components.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "paths": {
     "/Product/MetalComponent/MeasurementReport_v0.3": {
@@ -289,7 +289,7 @@
           }
         },
         "type": "object",
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "CustomerInformation": {
         "properties": {
@@ -306,7 +306,7 @@
             ],
             "title": "Name",
             "description": "The name of the customer that has issued the component order.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "department": {
             "anyOf": [
@@ -321,11 +321,11 @@
             ],
             "title": "Department",
             "description": "The responsible department of the customer that has issued the component order.",
-            "examples": ["Department xyz"]
+            "examples": ["Department Name"]
           }
         },
         "type": "object",
-        "title": "CustomerInformation"
+        "title": "Customer information"
       },
       "DataSourceError": {
         "properties": {
@@ -472,7 +472,7 @@
           }
         },
         "type": "object",
-        "title": "MeasurementEquipment"
+        "title": "Measurement equipment"
       },
       "MeasurementResult": {
         "properties": {
@@ -571,7 +571,7 @@
           }
         },
         "type": "object",
-        "title": "MeasurementResult"
+        "title": "Measurement result"
       },
       "MeasurementSetup": {
         "properties": {
@@ -646,7 +646,7 @@
               }
             ],
             "title": "Batch size",
-            "description": "The entire size of the batch that was manufactured under the same id.",
+            "description": "The entire size of the batch that was manufactured under the same ID.",
             "examples": [100]
           },
           "measuredItems": {
@@ -698,7 +698,7 @@
         },
         "type": "object",
         "required": ["measurementEquipment"],
-        "title": "MeasurementSetup"
+        "title": "Measurement setup"
       },
       "NotFound": {
         "properties": {
@@ -781,17 +781,14 @@
         "properties": {
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "customerInformation": {
             "$ref": "#/components/schemas/CustomerInformation",
-            "title": "Customer information",
             "description": "The details of the customer issuing the order for the component."
           },
           "measurementSetup": {
             "$ref": "#/components/schemas/MeasurementSetup",
-            "title": "Measurement setup",
             "description": "The details describing the quality measurement setup."
           },
           "measurementResults": {

--- a/DataProducts/Product/MetalComponent/Traceability_v0.3.json
+++ b/DataProducts/Product/MetalComponent/Traceability_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Metal component traceability information",
     "description": "The traceability information of a metal component.",
-    "version": "0.3.3"
+    "version": "0.3.4"
   },
   "paths": {
     "/Product/MetalComponent/Traceability_v0.3": {
@@ -293,7 +293,7 @@
           }
         },
         "type": "object",
-        "title": "CompanyIdentification"
+        "title": "Company identification"
       },
       "CompanyIdentifierScheme": {
         "type": "string",
@@ -318,10 +318,10 @@
           },
           "subComponentDeclaration": {
             "items": {
-              "$ref": "#/components/schemas/SubComponent"
+              "$ref": "#/components/schemas/Subcomponent"
             },
             "type": "array",
-            "title": "Sub component declaration",
+            "title": "Subcomponent declaration",
             "description": "List of declared subcomponents used in the component assembly."
           },
           "purchaseOrder": {
@@ -425,7 +425,7 @@
         },
         "type": "object",
         "required": ["subComponentDeclaration", "blanks"],
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "DataSourceError": {
         "properties": {
@@ -568,7 +568,7 @@
             ],
             "title": "Name",
             "description": "The registered trade name of the manufacturer company.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "identification": {
             "$ref": "#/components/schemas/CompanyIdentification",
@@ -603,12 +603,12 @@
             ],
             "title": "Contact email",
             "description": "The designated email contact for inquiries related to component manufacturing.",
-            "examples": ["contact@company.com"]
+            "examples": ["contact@example.com"]
           }
         },
         "type": "object",
         "required": ["identification"],
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "NotFound": {
         "properties": {
@@ -650,7 +650,7 @@
           }
         },
         "type": "object",
-        "title": "ProcessIdentification"
+        "title": "Process identification"
       },
       "QueryLevel": {
         "type": "string",
@@ -740,17 +740,14 @@
           },
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "manufacturerInformation": {
             "$ref": "#/components/schemas/ManufacturerInformation",
-            "title": "Manufacturer information",
             "description": "The details of the component manufacturer."
           },
           "processIdentification": {
-            "$ref": "#/components/schemas/ProcessIdentification",
-            "title": "Process identification"
+            "$ref": "#/components/schemas/ProcessIdentification"
           }
         },
         "type": "object",
@@ -782,7 +779,7 @@
         "title": "ServiceUnavailable",
         "description": "This response is reserved by Product Gateway."
       },
-      "SubComponent": {
+      "Subcomponent": {
         "properties": {
           "name": {
             "anyOf": [
@@ -816,7 +813,7 @@
           }
         },
         "type": "object",
-        "title": "SubComponent"
+        "title": "Subcomponent"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/Product/Sustainability/CarbonFootprint_v0.1.json
+++ b/DataProducts/Product/Sustainability/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Product carbon footprint",
     "description": "The carbon footprint of manufacturing a product.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Product/Sustainability/CarbonFootprint_v0.1": {
@@ -464,7 +464,7 @@
               }
             ],
             "title": "Logistics footprint (kg of CO2e)",
-            "description": "The carbon footprint generated from the upstream logisitics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
+            "description": "The carbon footprint generated from the upstream logistics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
             "examples": [0.3]
           }
         },

--- a/DataProducts/TimeAndDate/CurrentTime_v1.0.json
+++ b/DataProducts/TimeAndDate/CurrentTime_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Current time in a given country",
     "description": "Get the current time in a given country based on the ISO 3166-1 alpha-2 country code, formatted in RFC 3339 format.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/TimeAndDate/CurrentTime_v1.0": {
@@ -489,7 +489,7 @@
         },
         "type": "object",
         "required": ["countryCode"],
-        "title": "CurrentTimeRequest"
+        "title": "Current time request"
       },
       "CurrentTimeResponse": {
         "properties": {
@@ -500,7 +500,7 @@
         },
         "type": "object",
         "required": ["currentTime"],
-        "title": "CurrentTimeResponse"
+        "title": "Current time response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/Emissions_v0.1.json
+++ b/DataProducts/Transport/Vehicle/Emissions_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle emissions",
     "description": "The emissions of a transport vehicle.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Transport/Vehicle/Emissions_v0.1": {
@@ -336,7 +336,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "EmissionsRequest"
+        "title": "Emissions request"
       },
       "EmissionsResponse": {
         "properties": {
@@ -372,7 +372,7 @@
             "type": "number",
             "title": "Carbon dioxide (kg)",
             "description": "The mass of the carbon dioxide (CO2) emissions in kilograms.",
-            "examples": [4000]
+            "examples": [4000.0]
           },
           "nitrogenOxides": {
             "type": "number",
@@ -389,7 +389,7 @@
         },
         "type": "object",
         "required": ["carbonDioxide", "nitrogenOxides", "particulateMatter"],
-        "title": "EmissionsResponse"
+        "title": "Emissions response"
       },
       "Forbidden": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
+++ b/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Estimated arrival times",
     "description": "Estimated arrival times of vehicles within a transport location.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/Transport/Vehicle/EstimatedArrivalTimes_v0.2": {
@@ -352,7 +352,7 @@
         },
         "type": "object",
         "required": ["vehicleId", "estimatedArrival", "waybills"],
-        "title": "EstimatedArrival"
+        "title": "Estimated arrival"
       },
       "Forbidden": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/OperationalPerformance_v0.1.json
+++ b/DataProducts/Transport/Vehicle/OperationalPerformance_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle operational performance",
     "description": "General operational performance data of a transport vehicle.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Transport/Vehicle/OperationalPerformance_v0.1": {
@@ -412,7 +412,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -511,7 +511,7 @@
         },
         "type": "object",
         "required": ["runningHours", "distance"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
+++ b/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle operational status",
     "description": "General operational status data of a transport vehicle.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Transport/Vehicle/OperationalStatus_v0.1": {
@@ -357,7 +357,7 @@
             "type": "number",
             "title": "Latitude (°)",
             "description": "The latitude coordinate in decimal degrees.",
-            "examples": [60.192059],
+            "examples": [60.192],
             "gte": -90,
             "lte": 90
           },
@@ -365,7 +365,7 @@
             "type": "number",
             "title": "Longitude (°)",
             "description": "The longitude coordinate in decimal degrees.",
-            "examples": [24.945831],
+            "examples": [24.945],
             "gte": -180,
             "lte": 180
           }
@@ -421,7 +421,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalStatusRequest"
+        "title": "Operational status request"
       },
       "OperationalStatusResponse": {
         "properties": {
@@ -496,7 +496,7 @@
           }
         },
         "type": "object",
-        "title": "OperationalStatusResponse"
+        "title": "Operational status response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.3.json
+++ b/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Vehicle turnaround times",
     "description": "Turnaround times of vehicles within a facility.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "paths": {
     "/Transport/Vehicle/TurnaroundTimes_v0.3": {
@@ -475,7 +475,7 @@
         },
         "type": "object",
         "required": ["vehicleId", "entryTime"],
-        "title": "TurnaroundTime"
+        "title": "Turnaround time"
       },
       "TurnaroundTimeRequest": {
         "properties": {
@@ -503,7 +503,7 @@
         },
         "type": "object",
         "required": ["locationId", "startTime", "endTime"],
-        "title": "TurnaroundTimeRequest"
+        "title": "Turnaround time request"
       },
       "TurnaroundTimeResponse": {
         "properties": {
@@ -518,7 +518,7 @@
         },
         "type": "object",
         "required": ["turnaroundTimes"],
-        "title": "TurnaroundTimeResponse"
+        "title": "Turnaround time response"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/Weather/Current/Metric_v1.0.json
+++ b/DataProducts/Weather/Current/Metric_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Current weather in a given location",
     "description": "Common data points about the current weather with metric units in a given location. Simplified for example use, and not following industry standards.",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "paths": {
     "/Weather/Current/Metric_v1.0": {
@@ -233,7 +233,7 @@
             "minimum": -90.0,
             "title": "Latitude",
             "description": "The latitude coordinate of the desired location.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "lon": {
             "type": "number",
@@ -241,12 +241,12 @@
             "minimum": -180.0,
             "title": "Longitude",
             "description": "The longitude coordinate of the desired location.",
-            "examples": [24.945831]
+            "examples": [24.945]
           }
         },
         "type": "object",
         "required": ["lat", "lon"],
-        "title": "CurrentWeatherMetricRequest"
+        "title": "Current weather metric request"
       },
       "CurrentWeatherMetricResponse": {
         "properties": {
@@ -254,12 +254,12 @@
             "type": "number",
             "title": "Current relative air humidity (%)",
             "description": "Current relative air humidity in percentages.",
-            "examples": [72]
+            "examples": [72.0]
           },
           "pressure": {
             "type": "number",
             "title": "Current air pressure in hPa",
-            "examples": [1007]
+            "examples": [1007.0]
           },
           "rain": {
             "type": "boolean",
@@ -298,7 +298,7 @@
           "windSpeed",
           "windDirection"
         ],
-        "title": "CurrentWeatherMetricResponse"
+        "title": "Current weather metric response"
       },
       "DataSourceError": {
         "properties": {

--- a/DataProducts/test/ioxio-dataspace-guides/Country/BasicInfo.json
+++ b/DataProducts/test/ioxio-dataspace-guides/Country/BasicInfo.json
@@ -259,7 +259,7 @@
             "type": "number",
             "title": "Area",
             "description": "The area of the country in km^2",
-            "examples": [338455]
+            "examples": [338455.0]
           },
           "languages": {
             "items": {
@@ -294,7 +294,7 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "The name of the capital of the Country",
+            "description": "The name of the capital of the country",
             "examples": ["Helsinki"]
           },
           "lat": {
@@ -302,16 +302,16 @@
             "maximum": 90.0,
             "minimum": -90.0,
             "title": "Latitude",
-            "description": "The latitude coordinate of the Capital",
-            "examples": [60.170833]
+            "description": "The latitude coordinate of the capital",
+            "examples": [60.17]
           },
           "lon": {
             "type": "number",
             "maximum": 180.0,
             "minimum": -180.0,
             "title": "Longitude",
-            "description": "The longitude coordinate of the Capital",
-            "examples": [24.9375]
+            "description": "The longitude coordinate of the capital",
+            "examples": [24.937]
           }
         },
         "type": "object",

--- a/src/AirQuality/Current_v1.0.py
+++ b/src/AirQuality/Current_v1.0.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CurrentAirQualityRequest(CamelCaseModel):
@@ -9,7 +9,7 @@ class CurrentAirQualityRequest(CamelCaseModel):
         ...,
         title="Latitude",
         description="The latitude coordinate of the desired location.",
-        examples=[60.192059],
+        examples=[60.192],
         ge=-90,
         le=90,
     )
@@ -17,10 +17,12 @@ class CurrentAirQualityRequest(CamelCaseModel):
         ...,
         title="Longitude",
         description="The longitude coordinate of the desired location.",
-        examples=[24.945831],
+        examples=[24.945],
         ge=-180,
         le=180,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Current air quality request")
 
 
 class CurrentAirQualityResponse(CamelCaseModel):
@@ -52,6 +54,8 @@ class CurrentAirQualityResponse(CamelCaseModel):
             ]
         ],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Current air quality response")
 
 
 DEFINITION = DataProductDefinition(

--- a/src/Cargo/Metrics_v0.1.py
+++ b/src/Cargo/Metrics_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoType(str, Enum):
@@ -17,7 +17,7 @@ class CargoItem(CamelCaseModel):
         None,
         title="Weight (kg)",
         description="The weight of the cargo item in kilograms.",
-        examples=[2000],
+        examples=[2000.0],
     )
     volume: Optional[float] = Field(
         None,
@@ -44,6 +44,8 @@ class CargoItem(CamelCaseModel):
         examples=[1.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo item")
+
 
 class CargoMetricsRequest(CamelCaseModel):
     waybill_number: str = Field(
@@ -53,6 +55,8 @@ class CargoMetricsRequest(CamelCaseModel):
         max_length=128,
         examples=["5308956234"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Cargo metrics request")
 
 
 class CargoMetricsResponse(CamelCaseModel):
@@ -66,13 +70,13 @@ class CargoMetricsResponse(CamelCaseModel):
         None,
         title="Weight (kg)",
         description="The weight of the cargo within the delivery in kilograms.",
-        examples=[20000],
+        examples=[20000.0],
     )
     volume: Optional[float] = Field(
         None,
         title="Volume (m^3)",
         description="The volume of the cargo within the delivery in cubic meters.",
-        examples=[50],
+        examples=[50.0],
     )
     cargo_units: Optional[int] = Field(
         None,
@@ -86,9 +90,11 @@ class CargoMetricsResponse(CamelCaseModel):
         description="The details of the cargo items within the delivery.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo metrics response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Cargo metrics",
     description="The key metrics of the transported cargo",

--- a/src/CargoHandlingEquipment/OperationalPerformance_v0.1.py
+++ b/src/CargoHandlingEquipment/OperationalPerformance_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoMoves(CamelCaseModel):
@@ -20,6 +20,8 @@ class CargoMoves(CamelCaseModel):
         examples=[53],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo moves")
+
 
 class HoistMoves(CamelCaseModel):
     lift: Optional[int] = Field(
@@ -34,6 +36,8 @@ class HoistMoves(CamelCaseModel):
         description="Count of lowering moves the cargo handling equipment has performed during the time period.",
         examples=[164],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Hoist moves")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -82,6 +86,8 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[75.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 class OperationalPerformanceRequest(CamelCaseModel):
     id: str = Field(
@@ -108,9 +114,11 @@ class OperationalPerformanceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.4",
+    version="0.1.5",
     strict_validation=False,
     deprecated=True,
     title="Cargo handling equipment operational performance",

--- a/src/CargoHandlingEquipment/OperationalPerformance_v0.2.py
+++ b/src/CargoHandlingEquipment/OperationalPerformance_v0.2.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoMoves(CamelCaseModel):
@@ -20,6 +20,8 @@ class CargoMoves(CamelCaseModel):
         examples=[53],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo moves")
+
 
 class HoistMoves(CamelCaseModel):
     lift: Optional[int] = Field(
@@ -34,6 +36,8 @@ class HoistMoves(CamelCaseModel):
         description="Count of lowering moves the cargo handling equipment has performed during the time period.",
         examples=[164],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Hoist moves")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -82,6 +86,8 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[75.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 class OperationalPerformanceRequest(CamelCaseModel):
     id: str = Field(
@@ -108,9 +114,11 @@ class OperationalPerformanceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment operational performance",
     description="General operational status data of a mobile work machine operating in "

--- a/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
+++ b/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class OperationalState(str, Enum):
@@ -20,7 +20,7 @@ class Location(CamelCaseModel):
         description="The latitude coordinate in decimal degrees.",
         ge=-90.0,
         le=90.0,
-        examples=[60.192059],
+        examples=[60.192],
     )
     longitude: float = Field(
         ...,
@@ -28,8 +28,10 @@ class Location(CamelCaseModel):
         description="The longitude coordinate in decimal degrees.",
         ge=-180.0,
         le=180.0,
-        examples=[24.945831],
+        examples=[24.945],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class OperationalStatusResponse(CamelCaseModel):
@@ -83,6 +85,8 @@ class OperationalStatusResponse(CamelCaseModel):
         description="The location in GPS coordinates.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status response")
+
 
 class OperationalStatusRequest(CamelCaseModel):
     id: str = Field(
@@ -101,9 +105,11 @@ class OperationalStatusRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment operational status",
     description="General operational status data of a cargo handling equipment "

--- a/src/CargoHandlingEquipment/SustainabilityMetrics_v0.1.py
+++ b/src/CargoHandlingEquipment/SustainabilityMetrics_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class SustainabilityResponse(CamelCaseModel):
@@ -28,6 +28,8 @@ class SustainabilityResponse(CamelCaseModel):
         ge=0.0,
         examples=[560.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Sustainability response")
 
 
 class SustainabilityRequest(CamelCaseModel):
@@ -55,9 +57,11 @@ class SustainabilityRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Sustainability request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Cargo handling equipment sustainability metrics",
     description="The power source consumption for the sustainability evaluation of the "

--- a/src/Company/BasicInfo_v1.0.py
+++ b/src/Company/BasicInfo_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class BasicCompanyInfoRequest(CamelCaseModel):
@@ -9,6 +9,8 @@ class BasicCompanyInfoRequest(CamelCaseModel):
         description="The ID of the company.",
         examples=["2464491-9"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Basic company info request")
 
 
 class BasicCompanyInfoResponse(CamelCaseModel):
@@ -23,9 +25,11 @@ class BasicCompanyInfoResponse(CamelCaseModel):
         ..., title="Date of registration for the company", examples=["2012-02-23"]
     )
 
+    model_config: ConfigDict = ConfigDict(title="Basic company info response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Basic information about a company",
     description="Legal information about a company such as company registration date.",

--- a/src/Company/Recommendation_v1.0.py
+++ b/src/Company/Recommendation_v1.0.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class RecommendationRequest(CamelCaseModel):
@@ -11,6 +11,8 @@ class RecommendationRequest(CamelCaseModel):
         description="Keyword data to base recommendations on.",
         examples=["Looking for data product companies to invest on"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Recommendation request")
 
 
 class Recommendation(CamelCaseModel):
@@ -27,8 +29,10 @@ class Recommendation(CamelCaseModel):
         ...,
         title="Company name",
         description="Name of the Company being recommended.",
-        examples=["Digital Living Oy"],
+        examples=["IOXIO Oy"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Recommendation")
 
 
 class RecommendationResponse(CamelCaseModel):
@@ -36,9 +40,11 @@ class RecommendationResponse(CamelCaseModel):
         ..., title="Recommendation results", description="List of recommendations."
     )
 
+    model_config: ConfigDict = ConfigDict(title="Recommendation response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Company recommendations based on keywords",
     description="Recommendation of companies based on provided keywords. Each result has a score.",

--- a/src/Company/Shareholders_v1.0.py
+++ b/src/Company/Shareholders_v1.0.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ShareSeries(CamelCaseModel):
@@ -24,6 +24,8 @@ class ShareSeries(CamelCaseModel):
         examples=[1000],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Share series")
+
 
 class Ownerships(CamelCaseModel):
     series_name: str = Field(
@@ -39,6 +41,8 @@ class Ownerships(CamelCaseModel):
         examples=[100],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Ownerships")
+
 
 class Owners(CamelCaseModel):
     name: str = Field(
@@ -51,14 +55,18 @@ class Owners(CamelCaseModel):
         ..., title="Ownerships", description="List of Ownerships."
     )
 
+    model_config: ConfigDict = ConfigDict(title="Owners")
+
 
 class ShareholdersInfoRequest(CamelCaseModel):
     company_id: str = Field(
         ...,
         title="Company ID",
-        description="The ID of the company, only supports Finnish business ID's.",
+        description="The ID of the company.",
         examples=["2464491-9"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Shareholders info request")
 
 
 class ShareholdersInfoResponse(CamelCaseModel):
@@ -67,9 +75,11 @@ class ShareholdersInfoResponse(CamelCaseModel):
     )
     owners: List[Owners] = Field(..., title="Owners", description="List of owners")
 
+    model_config: ConfigDict = ConfigDict(title="Shareholders info response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="List of the shareholders of a company",
     description="Information about the shareholders of a company such as owners and shares quantity.",

--- a/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
+++ b/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class ManufacturingLocation(CamelCaseModel):
@@ -9,7 +9,7 @@ class ManufacturingLocation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the battery manufacturing location in Alpha-3 "
+        description="The country code of the battery manufacturing location in ISO 3166-1 alpha-3 "
         "format.",
         examples=["DEU"],
     )
@@ -20,6 +20,8 @@ class ManufacturingLocation(CamelCaseModel):
         description="The city of the battery manufacturing location.",
         examples=["Hamburg"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturing location")
 
 
 class ManufacturerInformation(CamelCaseModel):
@@ -74,6 +76,8 @@ class ManufacturerInformation(CamelCaseModel):
         examples=["info@example.com"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
+
 
 class CarbonFootprint(CamelCaseModel):
     pre_production_footprint: Optional[float] = Field(
@@ -101,6 +105,8 @@ class CarbonFootprint(CamelCaseModel):
         "supporting the carbon footprint values.",
         examples=["https://example.com/CarbonFootprint"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Carbon footprint")
 
 
 class CarbonFootprintResponse(CamelCaseModel):
@@ -136,6 +142,8 @@ class CarbonFootprintResponse(CamelCaseModel):
         "phases.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Carbon footprint response")
+
 
 class CarbonFootprintRequest(CamelCaseModel):
     product: str = Field(
@@ -148,14 +156,16 @@ class CarbonFootprintRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["660e8400-e29b-41d4-a716-446655440000"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Carbon footprint request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.5",
+    version="0.1.6",
     strict_validation=False,
     title="Battery carbon footprint",
     description="Carbon footprint of a battery as required by the European "

--- a/src/DigitalProductPassport/Battery/HealthData_v0.1.py
+++ b/src/DigitalProductPassport/Battery/HealthData_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Status(str, Enum):
@@ -49,6 +49,8 @@ class OriginalPerformance(CamelCaseModel):
         examples=[10],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Original performance")
+
 
 class OperationDetail(CamelCaseModel):
     measurement_date: Optional[datetime.date] = Field(
@@ -69,6 +71,8 @@ class OperationDetail(CamelCaseModel):
         description="The temperature of the battery measured in Celsius degrees.",
         examples=[8.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operation detail")
 
 
 class HealthState(CamelCaseModel):
@@ -105,6 +109,8 @@ class HealthState(CamelCaseModel):
         description="The periodic information of the battery operation.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health state")
+
 
 class HarmfulEvent(CamelCaseModel):
     event_date: Optional[datetime.date] = Field(
@@ -122,6 +128,8 @@ class HarmfulEvent(CamelCaseModel):
         examples=["30 minutes spent in extreme temperature -50 Celsius"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Harmful event")
+
 
 class HealthDataResponse(CamelCaseModel):
     status: Optional[Status] = Field(
@@ -133,14 +141,14 @@ class HealthDataResponse(CamelCaseModel):
     manufacturing_date: Optional[str] = Field(
         None,
         title="Manufacturing Date",
-        description="The date of manufacture using month and year.",
+        description="The date of manufacture in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2023-07"],
     )
     service_initiation_date: Optional[str] = Field(
         None,
         title="Service Initiation Date",
-        description="The date on which the battery was first commissioned.",
+        description="The date on which the battery was first commissioned in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2023-12"],
     )
@@ -161,6 +169,8 @@ class HealthDataResponse(CamelCaseModel):
         "battery.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health data response")
+
 
 class HealthDataRequest(CamelCaseModel):
     product: str = Field(
@@ -173,14 +183,16 @@ class HealthDataRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["660e8400-e29b-41d4-a716-446655440000"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health data request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.6",
+    version="0.1.7",
     strict_validation=False,
     deprecated=True,
     title="Battery Health Data",

--- a/src/DigitalProductPassport/Battery/HealthData_v0.2.py
+++ b/src/DigitalProductPassport/Battery/HealthData_v0.2.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Status(str, Enum):
@@ -49,6 +49,8 @@ class OriginalPerformance(CamelCaseModel):
         examples=[10],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Original performance")
+
 
 class OperationDetail(CamelCaseModel):
     measurement_date: Optional[datetime.date] = Field(
@@ -78,6 +80,8 @@ class OperationDetail(CamelCaseModel):
         description="The temperature of the battery measured in Celsius degrees.",
         examples=[40.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operation detail")
 
 
 class HealthState(CamelCaseModel):
@@ -132,6 +136,8 @@ class HealthState(CamelCaseModel):
         description="The periodic information of the battery operation.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health state")
+
 
 class HarmfulEvent(CamelCaseModel):
     event_date: Optional[datetime.date] = Field(
@@ -149,6 +155,8 @@ class HarmfulEvent(CamelCaseModel):
         examples=["30 minutes spent in extreme temperature -50 Celsius"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Harmful event")
+
 
 class HealthDataResponse(CamelCaseModel):
     status: Optional[Status] = Field(
@@ -160,14 +168,14 @@ class HealthDataResponse(CamelCaseModel):
     manufacturing_date: Optional[str] = Field(
         None,
         title="Manufacturing date",
-        description="The date of manufacture using month and year.",
+        description="The date of manufacture in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2023-07"],
     )
     service_initiation_date: Optional[str] = Field(
         None,
         title="Service initiation date",
-        description="The date on which the battery was first commissioned.",
+        description="The date on which the battery was first commissioned in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2023-12"],
     )
@@ -188,6 +196,8 @@ class HealthDataResponse(CamelCaseModel):
         "battery.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health data response")
+
 
 class HealthDataRequest(CamelCaseModel):
     product: str = Field(
@@ -200,14 +210,16 @@ class HealthDataRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["660e8400-e29b-41d4-a716-446655440000"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Health data request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Battery health data",
     description="The health and status data of a battery as required by Battery "

--- a/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class ManufacturingLocation(CamelCaseModel):
@@ -10,7 +10,7 @@ class ManufacturingLocation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the battery manufacturing location in Alpha-3 "
+        description="The country code of the battery manufacturing location in ISO 3166-1 alpha-3 "
         "format.",
         examples=["DEU"],
     )
@@ -21,6 +21,8 @@ class ManufacturingLocation(CamelCaseModel):
         description="The city of the battery manufacturing location.",
         examples=["Hamburg"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturing location")
 
 
 class ManufacturerInformation(CamelCaseModel):
@@ -57,7 +59,7 @@ class ManufacturerInformation(CamelCaseModel):
         title="Country",
         pattern=r"^[A-Z]{3}$",
         description="The country code of the manufacturer's headquarters location in "
-        "Alpha-3 format.",
+        "ISO 3166-1 alpha-3 format.",
         examples=["USA"],
     )
     website: Optional[str] = Field(
@@ -74,6 +76,8 @@ class ManufacturerInformation(CamelCaseModel):
         description="The email address of the manufacturer.",
         examples=["info@example.com"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class BatteryCategory(str, Enum):
@@ -99,6 +103,8 @@ class RoundTripEfficiency(CamelCaseModel):
         examples=[60.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Round trip efficiency")
+
 
 class VoltageLevels(CamelCaseModel):
     nominal_voltage: Optional[float] = Field(
@@ -120,6 +126,8 @@ class VoltageLevels(CamelCaseModel):
         examples=[180.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Voltage levels")
+
 
 class TemperatureRange(CamelCaseModel):
     minimum_temperature: Optional[float] = Field(
@@ -140,6 +148,8 @@ class TemperatureRange(CamelCaseModel):
         le=100,
         ge=-100,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Temperature range")
 
 
 class ExpectedLifetime(CamelCaseModel):
@@ -166,6 +176,8 @@ class ExpectedLifetime(CamelCaseModel):
         examples=["1C"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Expected lifetime")
+
 
 class MaterialComposition(CamelCaseModel):
     chemistry: List[str] = Field(
@@ -188,6 +200,8 @@ class MaterialComposition(CamelCaseModel):
         examples=[["Cobalt"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material composition")
+
 
 class RecycledContent(CamelCaseModel):
     substance_name: Optional[str] = Field(
@@ -205,6 +219,8 @@ class RecycledContent(CamelCaseModel):
         examples=[8.5],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Recycled content")
+
 
 class RenewableContent(CamelCaseModel):
     substance_name: Optional[str] = Field(
@@ -221,6 +237,8 @@ class RenewableContent(CamelCaseModel):
         "percentage by weight.",
         examples=[2.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Renewable content")
 
 
 class LegalConformity(CamelCaseModel):
@@ -246,6 +264,8 @@ class LegalConformity(CamelCaseModel):
         max_length=2083,
         examples=["https://example.com/EUdeclaration"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Legal conformity")
 
 
 class ManufacturingDataSheetResponse(CamelCaseModel):
@@ -281,7 +301,7 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     manufacturing_date: Optional[str] = Field(
         None,
         title="Manufacturing date",
-        description="The date of manufacture using month and year.",
+        description="The date of manufacture in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2023-07"],
     )
@@ -315,7 +335,7 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         None,
         title="Resistance (Ω)",
         description="The internal resistance of the battery pack in ohms.",
-        examples=[0],
+        examples=[0.1],
     )
     round_trip_efficiency: Optional[RoundTripEfficiency] = Field(
         None,
@@ -363,7 +383,7 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     warranty: Optional[str] = Field(
         None,
         title="Warranty",
-        description="The date when the battery warranty expires.",
+        description="The date when the battery warranty expires in ISO 8601 month format.",
         pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
         examples=["2028-07"],
     )
@@ -374,6 +394,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         "the battery.",
         examples=[["foam", "carbon dioxide"]],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet response")
 
 
 class ManufacturingDataSheetRequest(CamelCaseModel):
@@ -387,14 +409,16 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["660e8400-e29b-41d4-a716-446655440000"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.6",
+    version="0.1.8",
     strict_validation=False,
     title="Battery manufacturing data sheet",
     description="Manufacturing data sheet as required by Battery Passport "

--- a/src/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.py
+++ b/src/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EquipmentType(str, Enum):
@@ -33,7 +33,7 @@ class ManufacturerInformation(CamelCaseModel):
         max_length=250,
         title="Name",
         description="The registered trade name of the manufacturer company.",
-        examples=["Equipment Manufacturer Company X"],
+        examples=["Equipment Manufacturer Example LTD"],
     )
     website: Optional[str] = Field(
         None,
@@ -43,6 +43,8 @@ class ManufacturerInformation(CamelCaseModel):
         description="The website of the manufacturer.",
         examples=["https://example.com/"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class Batteries(CamelCaseModel):
@@ -83,6 +85,8 @@ class Batteries(CamelCaseModel):
         examples=[75.0],
         ge=0,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Batteries")
 
 
 class DataSheetResponse(CamelCaseModel):
@@ -156,6 +160,8 @@ class DataSheetResponse(CamelCaseModel):
         examples=[6000.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet response")
+
 
 class DataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -173,9 +179,11 @@ class DataSheetRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment data sheet",
     description="General as-built data of a cargo handling equipment operating in a "

--- a/src/DigitalProductPassport/EnvironmentalFootprint_v0.1.py
+++ b/src/DigitalProductPassport/EnvironmentalFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CarbonFootprint(CamelCaseModel):
@@ -42,6 +42,8 @@ class CarbonFootprint(CamelCaseModel):
         examples=["https://example.com/CarbonFootprint"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Carbon footprint")
+
 
 class MaterialWaste(CamelCaseModel):
     amount: Optional[float] = Field(
@@ -59,6 +61,8 @@ class MaterialWaste(CamelCaseModel):
         examples=["https://example.com/materialWaste"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material waste")
+
 
 class ProductEnvironmentalFootprintResponse(CamelCaseModel):
     carbon_footprint: CarbonFootprint = Field(
@@ -70,6 +74,10 @@ class ProductEnvironmentalFootprintResponse(CamelCaseModel):
         None,
         title="Material waste",
         description="The details of the material waste generated during production.",
+    )
+
+    model_config: ConfigDict = ConfigDict(
+        title="Product environmental footprint response"
     )
 
 
@@ -89,9 +97,13 @@ class ProductEnvironmentalFootprintRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(
+        title="Product environmental footprint request"
+    )
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.4",
+    version="0.1.5",
     strict_validation=False,
     title="Product environmental footprint",
     description="The environmental impact of the product manufacturing.",

--- a/src/DigitalProductPassport/FoodArtifact/NutritionalValues_v0.1.py
+++ b/src/DigitalProductPassport/FoodArtifact/NutritionalValues_v0.1.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class FatContent(CamelCaseModel):
@@ -18,6 +18,7 @@ class FatContent(CamelCaseModel):
 
 
 class EnergyContent(CamelCaseModel):
+    # TODO: These should probably be floats
     energy: int = Field(
         ...,
         title="Energy",
@@ -30,6 +31,8 @@ class EnergyContent(CamelCaseModel):
         description="The number of calories per 100g measured in kilocalories.",
         examples=[180],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Energy content")
 
 
 class NutritionalValuesRequest(CamelCaseModel):
@@ -45,6 +48,8 @@ class NutritionalValuesRequest(CamelCaseModel):
         description="Unique identifier of the product.",
         examples=["550e8400-e29b-41d4-a716-446655440000"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Nutritional values request")
 
 
 class NutritionalValuesResponse(CamelCaseModel):
@@ -83,9 +88,11 @@ class NutritionalValuesResponse(CamelCaseModel):
         examples=[0.01],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Nutritional values response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Food Artifact Nutritional Values",
     description="Returns the nutritional values of a food product.",

--- a/src/DigitalProductPassport/LogisticsEmissions_v0.1.py
+++ b/src/DigitalProductPassport/LogisticsEmissions_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class FreightType(str, Enum):
@@ -77,6 +77,8 @@ class EmissionsPerTCE(CamelCaseModel):
         examples=["Diesel"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Emissions per TCE")
+
 
 class RoadLeg(CamelCaseModel):
     leg_identifier: Optional[str] = Field(
@@ -136,7 +138,7 @@ class RoadLeg(CamelCaseModel):
         title="Emission Intensity",
         description="The GHG emission intensity of the road transport "
         "per transported tonne and kilometer in CO2e grams / tonne / km.",
-        examples=[200],
+        examples=[200.0],
     )
     emissions_per_tce: List[EmissionsPerTCE] = Field(
         ...,
@@ -144,6 +146,8 @@ class RoadLeg(CamelCaseModel):
         description="The GHG emissions of the transport chain element related to the "
         "road transport leg.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Road leg")
 
 
 class SeaLeg(CamelCaseModel):
@@ -198,7 +202,7 @@ class SeaLeg(CamelCaseModel):
         title="Emission Intensity",
         description="The GHG emission intensity of the sea transport per "
         "transported tonne and kilometer in CO2e grams / tonne / km.",
-        examples=[500],
+        examples=[500.0],
     )
     emissions_per_tce: List[EmissionsPerTCE] = Field(
         ...,
@@ -206,6 +210,8 @@ class SeaLeg(CamelCaseModel):
         description="The GHG emissions of the transport chain element related to the "
         "sea transport leg.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Sea leg")
 
 
 class LogisticsEmissionsRequest(CamelCaseModel):
@@ -221,6 +227,8 @@ class LogisticsEmissionsRequest(CamelCaseModel):
         description="Unique identifier of the product.",
         examples=["550e8400-e29b-41d4-a716-446655440000"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Logistics emissions request")
 
 
 class LogisticsEmissionsResponse(CamelCaseModel):
@@ -241,9 +249,11 @@ class LogisticsEmissionsResponse(CamelCaseModel):
         max_length=20,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Logistics emissions response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Logistics Emissions",
     description="Returns the total emission per leg for "

--- a/src/DigitalProductPassport/Machine/ComponentSerialNumbers_v0.1.py
+++ b/src/DigitalProductPassport/Machine/ComponentSerialNumbers_v0.1.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class SerialNumber(CamelCaseModel):
@@ -20,6 +20,8 @@ class SerialNumber(CamelCaseModel):
         examples=["S05001"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Serial number")
+
 
 class MachineSerialNumberResponse(CamelCaseModel):
     serial_numbers: list[SerialNumber] = Field(
@@ -27,6 +29,8 @@ class MachineSerialNumberResponse(CamelCaseModel):
         title="Component serial numbers",
         description="Serial numbers of components of the machine.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Machine serial number response")
 
 
 class MachineSerialNumberRequest(CamelCaseModel):
@@ -45,9 +49,11 @@ class MachineSerialNumberRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Machine serial number request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Machine component serial numbers",
     description="List serial numbers of components in a machine.",

--- a/src/DigitalProductPassport/Machine/QualityMetrics_v0.2.py
+++ b/src/DigitalProductPassport/Machine/QualityMetrics_v0.2.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Measurement(CamelCaseModel):
@@ -50,6 +50,8 @@ class Measurement(CamelCaseModel):
         examples=[1.45],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement")
+
 
 class Metric(CamelCaseModel):
     identification: str = Field(
@@ -79,6 +81,8 @@ class Metric(CamelCaseModel):
         description="Quality metric measurements for the component.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Metric")
+
 
 class QualityMetricsResponse(CamelCaseModel):
     metrics: List[Metric] = Field(
@@ -86,6 +90,8 @@ class QualityMetricsResponse(CamelCaseModel):
         title="Metrics",
         description="List of metrics per component.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Quality metrics response")
 
 
 class QualityMetricsRequest(CamelCaseModel):
@@ -104,9 +110,11 @@ class QualityMetricsRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Quality metrics request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Measured quality metrics of a machine",
     description="Quality monitoring data for machines, including product serial number "

--- a/src/DigitalProductPassport/MetalArtifact/DataSheet_v0.1.py
+++ b/src/DigitalProductPassport/MetalArtifact/DataSheet_v0.1.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EnStandardCertification(CamelCaseModel):
@@ -13,6 +13,8 @@ class EnStandardCertification(CamelCaseModel):
         "compliant with.",
         examples=["EN 10002-1"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="EN Standard certification")
 
 
 class Measures(CamelCaseModel):
@@ -35,6 +37,8 @@ class Measures(CamelCaseModel):
         examples=[0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measures")
+
 
 class MetalArtifactDataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -49,6 +53,8 @@ class MetalArtifactDataSheetRequest(CamelCaseModel):
         description="Unique identifier of the product.",
         examples=["550e8400-e29b-41d4-a716-446655440000"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Metal artifact data sheet request")
 
 
 class MetalArtifactDataSheetResponse(CamelCaseModel):
@@ -85,9 +91,11 @@ class MetalArtifactDataSheetResponse(CamelCaseModel):
         description="The list of EN standards.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Metal artifact data sheet response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Data Sheet For Metal Artifacts",
     description="Returns the basic product information of a metal product.",

--- a/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class ManufacturerInformation(CamelCaseModel):
@@ -38,7 +38,7 @@ class ManufacturerInformation(CamelCaseModel):
         title="Country",
         pattern=r"^[A-Z]{3}$",
         description="The country code of the manufacturer's headquarters location in "
-        "Alpha-3 format.",
+        "ISO 3166-1 alpha-3 format.",
         examples=["SWE"],
     )
     website: Optional[str] = Field(
@@ -55,6 +55,8 @@ class ManufacturerInformation(CamelCaseModel):
         description="The email address of the battery manufacturer.",
         examples=["info@example.com"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class ManufacturingDataSheetResponse(CamelCaseModel):
@@ -127,6 +129,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         examples=["https://example.com/safetyDocument"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet response")
+
 
 class ManufacturingDataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -139,14 +143,16 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     deprecated=True,
     title="Drill Manufacturing Data Sheet",

--- a/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.2.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.2.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class PowerSystemType(str, Enum):
@@ -45,7 +45,7 @@ class ManufacturerInformation(CamelCaseModel):
         title="Country",
         pattern=r"^[A-Z]{3}$",
         description="The country code of the manufacturer's headquarters location in "
-        "Alpha-3 format.",
+        "ISO 3166-1 alpha-3 format.",
         examples=["SWE"],
     )
     website: Optional[str] = Field(
@@ -63,6 +63,8 @@ class ManufacturerInformation(CamelCaseModel):
         examples=["info@example.com"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
+
 
 class ElectricMotors(CamelCaseModel):
     motor_type: Optional[str] = Field(
@@ -79,6 +81,8 @@ class ElectricMotors(CamelCaseModel):
         ge=0,
         examples=[2],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Electric motors")
 
 
 class Batteries(CamelCaseModel):
@@ -104,6 +108,8 @@ class Batteries(CamelCaseModel):
         examples=[2],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Batteries")
+
 
 class PowerSystem(CamelCaseModel):
     type: Optional[PowerSystemType] = Field(
@@ -122,6 +128,8 @@ class PowerSystem(CamelCaseModel):
         title="Batteries",
         description="The list of batteries in the machine.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Power system")
 
 
 class ManufacturingDataSheetResponse(CamelCaseModel):
@@ -196,6 +204,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         examples=["https://example.com/safetyDocument"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet response")
+
 
 class ManufacturingDataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -208,14 +218,16 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Drill Manufacturing Data Sheet",
     description="Manufacturing data sheet of a Mobile Drill Machine.",

--- a/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CarbonFootprint(CamelCaseModel):
@@ -29,6 +29,8 @@ class CarbonFootprint(CamelCaseModel):
         examples=["https://example.com/CarbonFootprint"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Carbon footprint")
+
 
 class MaterialWaste(CamelCaseModel):
     amount: Optional[float] = Field(
@@ -48,6 +50,8 @@ class MaterialWaste(CamelCaseModel):
         examples=["https://example.com/CarbonFootprint"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material waste")
+
 
 class DataSheetResponse(CamelCaseModel):
     carbon_footprint: CarbonFootprint = Field(
@@ -62,6 +66,8 @@ class DataSheetResponse(CamelCaseModel):
         description="The details of the material waste generated during the production.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet response")
+
 
 class DataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -74,14 +80,16 @@ class DataSheetRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Mobile Work Machine Environmental Footprint",
     description="Carbon Footprint of a Mobile Work Machine.",

--- a/src/DigitalProductPassport/MobileWorkMachine/StraddleCarrier/OperationsData_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/StraddleCarrier/OperationsData_v0.1.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class OperationsDataResponse(CamelCaseModel):
@@ -22,6 +22,8 @@ class OperationsDataResponse(CamelCaseModel):
         examples=[350.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operations data response")
+
 
 class OperationsDataRequest(CamelCaseModel):
     product: str = Field(
@@ -34,14 +36,16 @@ class OperationsDataRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product",
         examples=["faf1e386-6a07-4f89-bdbe-b0a6a6241c69"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operations data request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Straddle carrier operations data",
     description="Operations data of a straddle carrier to retrieve fuel use, "

--- a/src/DigitalProductPassport/Product/CarbonFootprint_v0.1.py
+++ b/src/DigitalProductPassport/Product/CarbonFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Request(CamelCaseModel):
@@ -21,6 +21,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -43,9 +45,11 @@ class Response(CamelCaseModel):
         examples=[0.3],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Product carbon footprint",
     description="The carbon footprint of manufacturing a product.",

--- a/src/DigitalProductPassport/Product/FIBC/ProductDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Product/FIBC/ProductDataSheet_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class FIBCType(str, Enum):
@@ -55,7 +55,7 @@ class ManufacturingInformation(CamelCaseModel):
     production_country: Optional[str] = Field(
         None,
         title="Production country",
-        description="Country where the product was produced, in ISO 3166-1 alpha-3.",
+        description="Country where the product was produced, in ISO 3166-1 alpha-3 format.",
         pattern=r"^[A-Z]{3}$",
         min_length=3,
         max_length=3,
@@ -75,8 +75,11 @@ class ManufacturingInformation(CamelCaseModel):
         examples=[["ISO 21898", "HACCP"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing information")
+
 
 class Dimensions(CamelCaseModel):
+    # TODO: These should likely be floats
     external_width: Optional[int] = Field(
         None,
         title="External width (cm)",
@@ -120,6 +123,8 @@ class Dimensions(CamelCaseModel):
         examples=[0.98397],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Dimensions")
+
 
 class Loops(CamelCaseModel):
     type: Optional[str] = Field(
@@ -133,7 +138,7 @@ class Loops(CamelCaseModel):
         None,
         title="Height (cm)",
         description="Height of the loops, in centimeters.",
-        examples=[30],
+        examples=[30.0],
     )
     color: Optional[str] = Field(
         None,
@@ -142,6 +147,8 @@ class Loops(CamelCaseModel):
         max_length=40,
         examples=["Red"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Loops")
 
 
 class Body(CamelCaseModel):
@@ -173,19 +180,21 @@ class Body(CamelCaseModel):
         examples=["White"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Body")
+
 
 class TopSpout(CamelCaseModel):
     diameter: Optional[float] = Field(
         None,
         title="Diameter (cm)",
         description="Diameter of the top spout, in centimeters.",
-        examples=[40],
+        examples=[40.0],
     )
     length: Optional[float] = Field(
         None,
         title="Length (cm)",
         description="Length of the top spout, in centimeters.",
-        examples=[50],
+        examples=[50.0],
     )
     coating_applied: Optional[bool] = Field(
         None,
@@ -201,19 +210,21 @@ class TopSpout(CamelCaseModel):
         examples=["White"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Top spout")
+
 
 class Bottom(CamelCaseModel):
     diameter: Optional[float] = Field(
         None,
         title="Diameter (cm)",
         description="Diameter of the bottom part, in centimeters.",
-        examples=[60],
+        examples=[60.0],
     )
     length: Optional[float] = Field(
         None,
         title="Length (cm)",
         description="Length of the bottom part, in centimeters.",
-        examples=[60],
+        examples=[60.0],
     )
     coating_applied: Optional[bool] = Field(
         None,
@@ -229,6 +240,8 @@ class Bottom(CamelCaseModel):
         examples=["White"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Bottom")
+
 
 class Liner(CamelCaseModel):
     type: Optional[str] = Field(
@@ -242,7 +255,7 @@ class Liner(CamelCaseModel):
         None,
         title="Thickness (µm)",
         description="Thickness of the liner, microns.",
-        examples=[100],
+        examples=[100.0],
     )
     color: Optional[str] = Field(
         None,
@@ -251,6 +264,8 @@ class Liner(CamelCaseModel):
         max_length=40,
         examples=["Transparent"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Liner")
 
 
 class Request(CamelCaseModel):
@@ -269,6 +284,8 @@ class Request(CamelCaseModel):
         examples=["123456789"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     model: Optional[str] = Field(
@@ -284,6 +301,7 @@ class Response(CamelCaseModel):
         description="Type of the FIBC bag.",
         examples=[FIBCType.B],
     )
+    # TODO: Should be float
     safe_working_load: Optional[int] = Field(
         None,
         title="Safe working load (kg)",
@@ -302,6 +320,7 @@ class Response(CamelCaseModel):
         description="Is the product UV resistant?",
         examples=[True],
     )
+    # TODO: Should be float
     uv_guarantee_years: Optional[int] = Field(
         None,
         title="UV guarantee years",
@@ -383,9 +402,11 @@ class Response(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="FIBC Product data sheet",
     description="Product data sheet for FIBC bulk bags.",

--- a/src/DigitalProductPassport/Product/FIBC/SustainabilityDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Product/FIBC/SustainabilityDataSheet_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class RawMaterialEmissions(CamelCaseModel):
@@ -12,6 +12,8 @@ class RawMaterialEmissions(CamelCaseModel):
         examples=[4.8],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Raw material emissions")
+
 
 class ProcessingEmissions(CamelCaseModel):
     emissions: Optional[float] = Field(
@@ -21,13 +23,15 @@ class ProcessingEmissions(CamelCaseModel):
         examples=[3.9],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Processing emissions")
+
 
 class TransportEmissions(CamelCaseModel):
     transport_length: Optional[float] = Field(
         None,
         title="Transport length (km)",
         description="Length of the upstream transport, from manufacturer to customer in kilometers.",
-        examples=[350],
+        examples=[350.0],
     )
     fuel_type: Optional[str] = Field(
         None,
@@ -42,6 +46,8 @@ class TransportEmissions(CamelCaseModel):
         description="Transport emissions for the bag, kilograms of CO2e.",
         examples=[0.3],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Transport emissions")
 
 
 class Request(CamelCaseModel):
@@ -60,13 +66,15 @@ class Request(CamelCaseModel):
         examples=["123456789"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     carbon_footprint: Optional[float] = Field(
         None,
         title="Carbon footprint (kg of CO2e)",
         description="Manufacturing carbon footprint of the bag, kilograms of CO2e.",
-        examples=[4],
+        examples=[4.0],
     )
     raw_material_emissions: RawMaterialEmissions = Field(
         ...,
@@ -89,7 +97,7 @@ class Response(CamelCaseModel):
         description="The percentage of the FIBC bag made from recycled materials.",
         gte=0,
         lte=100,
-        examples=[30],
+        examples=[30.0],
     )
     is_recyclable: Optional[bool] = Field(
         None,
@@ -114,9 +122,11 @@ class Response(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="FIBC sustainability data sheet",
     description="Basic sustainability data sheet for FIBC bulk bags.",

--- a/src/DigitalProductPassport/Product/GrainPassport_v0.1.py
+++ b/src/DigitalProductPassport/Product/GrainPassport_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ProductionMethod(str, Enum):
@@ -54,7 +54,7 @@ class RecipientInformation(CamelCaseModel):
     country: Optional[str] = Field(
         None,
         title="Country",
-        description="Recipient country in ISO 3166-1 alpha-3.",
+        description="Recipient country in ISO 3166-1 alpha-3 format.",
         pattern=r"^[A-Z]{3}$",
         min_length=3,
         max_length=3,
@@ -81,12 +81,14 @@ class RecipientInformation(CamelCaseModel):
         examples=["Brewing Company Oy"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Recipient information")
+
 
 class GrowthRegulatorDetails(CamelCaseModel):
     growth_regulator_date: Optional[date] = Field(
         None,
         title="Growth regulator date",
-        description="Date of growth regulator application.",
+        description="Date of growth regulator application in ISO 8601 format.",
         examples=[date.fromisoformat("2024-04-15")],
     )
     growth_regulator_type: Optional[str] = Field(
@@ -96,6 +98,8 @@ class GrowthRegulatorDetails(CamelCaseModel):
         max_length=150,
         examples=["Moddus Evo"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Growth regulator details")
 
 
 class FarmerInformation(CamelCaseModel):
@@ -120,6 +124,7 @@ class FarmerInformation(CamelCaseModel):
         max_length=150,
         examples=["Example road 1"],
     )
+    # TODO: Should be called postal code
     zipcode: Optional[str] = Field(
         None,
         title="ZIP Code",
@@ -137,7 +142,7 @@ class FarmerInformation(CamelCaseModel):
     country: Optional[str] = Field(
         None,
         title="Country",
-        description="Country of the producing farm in ISO 3166-1 alpha-3.",
+        description="Country of the producing farm in ISO 3166-1 alpha-3 format.",
         pattern=r"^[A-Z]{3}$",
         min_length=3,
         max_length=3,
@@ -174,6 +179,8 @@ class FarmerInformation(CamelCaseModel):
         examples=["John Doe"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Farmer information")
+
 
 class TransportInformation(CamelCaseModel):
     company: str = Field(
@@ -201,7 +208,7 @@ class TransportInformation(CamelCaseModel):
         None,
         title="Shipment weight (kg)",
         description="Weight of the shipment in kg.",
-        examples=[28500],
+        examples=[28500.0],
     )
     loading_time: Optional[datetime] = Field(
         None,
@@ -218,7 +225,7 @@ class TransportInformation(CamelCaseModel):
     previous_content_date: Optional[date] = Field(
         None,
         title="Previous content date",
-        description="Date of the previous transportation with the truck in question, in RFC 3339 format.",
+        description="Date of the previous transportation with the truck in question, in ISO 8601 format.",
         examples=[date.fromisoformat("2025-02-20")],
     )
     previous_content: Optional[str] = Field(
@@ -235,6 +242,8 @@ class TransportInformation(CamelCaseModel):
         max_length=150,
         examples=["Water and detergent"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Transport information")
 
 
 class Request(CamelCaseModel):
@@ -253,6 +262,8 @@ class Request(CamelCaseModel):
         examples=["123456789"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     grain_passport_number: str = Field(
@@ -265,7 +276,7 @@ class Response(CamelCaseModel):
     creation_date: date = Field(
         ...,
         title="Creation date",
-        description="Grain passport creation date.",
+        description="Grain passport creation date in ISO 8601 format.",
         examples=[date.fromisoformat("2025-02-20")],
     )
     grain_type: str = Field(
@@ -285,7 +296,7 @@ class Response(CamelCaseModel):
     harvest_year: int = Field(
         ...,
         title="Harvest year",
-        description="Year of harvesting.",
+        description="Year of harvesting in YYYY format.",
         gte=1900,
         lte=2500,
         examples=[2024],
@@ -312,9 +323,11 @@ class Response(CamelCaseModel):
         description="Information about the transporting parties.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Grain Passport",
     description="Digital Product Passport for one shipment of grains.",

--- a/src/DigitalProductPassport/RockDrill/DataSheet_v0.1.py
+++ b/src/DigitalProductPassport/RockDrill/DataSheet_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class ManufacturerInformation(CamelCaseModel):
@@ -38,7 +38,7 @@ class ManufacturerInformation(CamelCaseModel):
         pattern=r"^[A-Z]{3}$",
         title="Country",
         description="The country code of the manufacturer's headquarters location "
-        "in Alpha-3 format.",
+        "in ISO 3166-1 alpha-3 format.",
         examples=["SWE"],
     )
     website: Optional[str] = Field(
@@ -56,13 +56,15 @@ class ManufacturerInformation(CamelCaseModel):
         examples=["info@example.com"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
+
 
 class ManufacturingLocation(CamelCaseModel):
     country: Optional[str] = Field(
         None,
         pattern=r"^[A-Z]{3}$",
         title="Country",
-        description="The country code of the manufacturing location in Alpha-3 format.",
+        description="The country code of the manufacturing location in ISO 3166-1 alpha-3 format.",
         examples=["DEU"],
     )
     city: Optional[str] = Field(
@@ -72,6 +74,8 @@ class ManufacturingLocation(CamelCaseModel):
         description="The city of the manufacturing location.",
         examples=["Hamburg"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturing location")
 
 
 class DataSheetResponse(CamelCaseModel):
@@ -96,31 +100,31 @@ class DataSheetResponse(CamelCaseModel):
         None,
         title="Minimum hole diameter (mm)",
         description="The minimum diameter of the drilling hole in millimeters.",
-        examples=[76],
+        examples=[76.0],
     )
     maximum_hole_diameter: Optional[float] = Field(
         None,
         title="Maximum hole diameter (mm)",
         description="The maximum diameter of the drilling hole in millimeters.",
-        examples=[127],
+        examples=[127.0],
     )
     weight: Optional[float] = Field(
         None,
         title="Weight (kg)",
         description="The net weight of the product in kilograms.",
-        examples=[200],
+        examples=[200.0],
     )
     percussion_rate: Optional[float] = Field(
         None,
         title="Percussion rate (Hz)",
         description="The frequency at which drill percussive action occurs in hertz.",
-        examples=[50],
+        examples=[50.0],
     )
     drilling_power: Optional[float] = Field(
         None,
         title="Drilling power (kW)",
         description="The maximum drilling power in kilowatts.",
-        examples=[160],
+        examples=[160.0],
     )
     reference_data_sheet: Optional[str] = Field(
         None,
@@ -147,6 +151,8 @@ class DataSheetResponse(CamelCaseModel):
         examples=["https://example.com/safetyManual"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet response")
+
 
 class DataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -164,9 +170,11 @@ class DataSheetRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.5",
+    version="0.1.6",
     strict_validation=False,
     title="Rock drill data sheet",
     description="General as-built data of a rock drill.",

--- a/src/DigitalProductPassport/RockDrill/Piston/MaterialCertificate_v0.2.py
+++ b/src/DigitalProductPassport/RockDrill/Piston/MaterialCertificate_v0.2.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class InspectionConformity(CamelCaseModel):
@@ -25,6 +25,8 @@ class InspectionConformity(CamelCaseModel):
         description="The standard(s) defining the test requirements.",
         examples=[["EN 11223", "ISO 1234-5"]],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Inspection conformity")
 
 
 class MaterialCertificateResponse(CamelCaseModel):
@@ -63,6 +65,8 @@ class MaterialCertificateResponse(CamelCaseModel):
         description="The details of the conformity with the legal and standard requirements.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material certificate response")
+
 
 class MaterialCertificateRequest(CamelCaseModel):
     product: str = Field(
@@ -79,6 +83,8 @@ class MaterialCertificateRequest(CamelCaseModel):
         description="The unique identifier of the product.",
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Material certificate request")
 
 
 DEFINITION = DataProductDefinition(

--- a/src/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ComponentType(str, Enum):
@@ -38,6 +38,8 @@ class ColorInformation(CamelCaseModel):
         examples=["19-4052 TCX"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Color information")
+
 
 class Material(CamelCaseModel):
     name: str = Field(
@@ -54,7 +56,7 @@ class Material(CamelCaseModel):
         description="The percentage of material content in the component, expressed as a percentage by weight.",
         gte=0,
         lte=100,
-        examples=[50],
+        examples=[50.0],
     )
     recycling_rate: Optional[float] = Field(
         None,
@@ -62,8 +64,10 @@ class Material(CamelCaseModel):
         description="The amount of recycled content in the material substance, expressed as a percentage by weight.",
         gte=0,
         lte=100,
-        examples=[50],
+        examples=[50.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Material")
 
 
 class Chemical(CamelCaseModel):
@@ -82,6 +86,8 @@ class Chemical(CamelCaseModel):
         examples=["200-001-8"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Chemical")
+
 
 class Component(CamelCaseModel):
     name: str = Field(
@@ -90,7 +96,7 @@ class Component(CamelCaseModel):
         description="The name of the component in the garment.",
         min_length=0,
         max_length=40,
-        examples=["zipper xyz / fabric silk xyz"],
+        examples=["zipper", "fabric silk"],
     )
     type: ComponentType = Field(
         ...,
@@ -114,6 +120,8 @@ class Component(CamelCaseModel):
         description="List of chemicals used in the component.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component")
+
 
 class Request(CamelCaseModel):
     product: str = Field(
@@ -133,6 +141,8 @@ class Request(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     outer_components: list[Component] = Field(
@@ -151,9 +161,11 @@ class Response(CamelCaseModel):
         description="List of all notions and trim components. The notions and trim components include fabrics and other structures used for the functional and decorative elements of the garment, including safety elements, refinement features and sewing threads.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Garment Bill of Materials",
     description="Details of the garment's bill of materials.",

--- a/src/DigitalProductPassport/Textile/Garment/MaintenanceLog_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/MaintenanceLog_v0.1.py
@@ -2,14 +2,14 @@ from datetime import date
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Event(CamelCaseModel):
     event_date: Optional[date] = Field(
         None,
         title="Event date",
-        description="The date of the event.",
+        description="The date of the event in ISO 8601 format.",
         examples=[date.fromisoformat("2024-02-10")],
     )
     event_description: Optional[str] = Field(
@@ -20,6 +20,8 @@ class Event(CamelCaseModel):
         max_length=250,
         examples=["Stitched a hole in the left arm"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Event")
 
 
 class Request(CamelCaseModel):
@@ -40,12 +42,14 @@ class Request(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     commissioning_date: date = Field(
         ...,
         title="Commissioning date",
-        description="The date when the garment was delivered to the customer.",
+        description="The date when the garment was delivered to the customer in ISO 8601 format.",
         examples=[date.fromisoformat("2023-06-01")],
     )
     washing_cycles: int = Field(
@@ -65,9 +69,11 @@ class Response(CamelCaseModel):
         description="The list of harmful events the garment has been exposed to which have an effect on the repairability and recyclability.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Garment maintenance log",
     description="Details of the garment's care, repair and incidents.",

--- a/src/DigitalProductPassport/Textile/Garment/ManufacturerInformation_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/ManufacturerInformation_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ManufacturingPhase(str, Enum):
@@ -18,7 +18,7 @@ class ManufacturingLocation(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code of the manufacturing location in Alpha-3 format.",
+        description="The country code of the manufacturing location in ISO 3166-1 alpha-3 format.",
         pattern=r"^[A-Z]{3}$",
         examples=["POL"],
     )
@@ -31,6 +31,8 @@ class ManufacturingLocation(CamelCaseModel):
         examples=["Warsaw"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing location")
+
 
 class Manufacturer(CamelCaseModel):
     manufacturing_phase: ManufacturingPhase = Field(
@@ -42,7 +44,7 @@ class Manufacturer(CamelCaseModel):
     manufacturing_date: date = Field(
         ...,
         title="Manufacturing date",
-        description="The date of the garment was manufactured.",
+        description="The date of the garment was manufactured in ISO 8601 format.",
         examples=[date.fromisoformat("2023-01-01")],
     )
     manufacturer_name: str = Field(
@@ -61,11 +63,13 @@ class Manufacturer(CamelCaseModel):
     facility_id: Optional[str] = Field(
         None,
         title="Facility ID",
-        description="The facility id of the manufacturing site in the GLN format.",
+        description="The facility ID of the manufacturing site in the GLN format.",
         min_length=0,
         max_length=40,
         examples=["1234567000004"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer")
 
 
 class Request(CamelCaseModel):
@@ -86,6 +90,8 @@ class Request(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     manufacturers: list[Manufacturer] = Field(
@@ -94,9 +100,11 @@ class Response(CamelCaseModel):
         description="The manufacturer details.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Garment manufacturer information",
     description="Details of the garment manufacturers and facilities.",

--- a/src/DigitalProductPassport/Textile/Garment/MaterialDisclosureSheet_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/MaterialDisclosureSheet_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Material(CamelCaseModel):
@@ -29,6 +29,8 @@ class Material(CamelCaseModel):
         lte=100,
         examples=[50.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Material")
 
 
 class MaterialInformation(CamelCaseModel):
@@ -61,6 +63,8 @@ class MaterialInformation(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material information")
+
 
 class Request(CamelCaseModel):
     product: str = Field(
@@ -80,6 +84,8 @@ class Request(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     outer_material_information: MaterialInformation = Field(
@@ -98,9 +104,11 @@ class Response(CamelCaseModel):
         description="Information about the notions and trim materials that make up 5% or more of the garment's total weight. Notions and trim materials are used for functional and decorative elements of the garment, including safety components, refinement features, and sewing threads.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Garment material disclosure sheet",
     description="Public summary of the garment's material composition, recycled content and material level certifications.",

--- a/src/DigitalProductPassport/Textile/Garment/ProductDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/ProductDataSheet_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Gender(str, Enum):
@@ -50,6 +50,8 @@ class CompanyIdentification(CamelCaseModel):
         examples=["1234567890123"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Company identification")
+
 
 class BrandInformation(CamelCaseModel):
     name: str = Field(
@@ -74,6 +76,8 @@ class BrandInformation(CamelCaseModel):
         description="The identification of the company being responsible of the DPP.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Brand information")
+
 
 class SizeInformation(CamelCaseModel):
     sizing_system: Optional[SizingSystem] = Field(
@@ -90,6 +94,8 @@ class SizeInformation(CamelCaseModel):
         max_length=10,
         examples=["40"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Size information")
 
 
 class ColorInformation(CamelCaseModel):
@@ -114,6 +120,8 @@ class ColorInformation(CamelCaseModel):
         examples=["19-4052 TCX"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Color information")
+
 
 class Request(CamelCaseModel):
     product: str = Field(
@@ -132,6 +140,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -221,9 +231,11 @@ class Response(CamelCaseModel):
         examples=["https://example.com/"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Garment product data sheet",
     description="General specifications of a garment.",

--- a/src/Energy/Battery/ChargingHistory_v1.0.py
+++ b/src/Energy/Battery/ChargingHistory_v1.0.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ChargingHistoryRequest(CamelCaseModel):
@@ -38,6 +38,8 @@ class ChargingHistoryRequest(CamelCaseModel):
         description="Offset of history records to return.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Charging history request")
+
 
 class ChargingHistoryEntry(CamelCaseModel):
     time: datetime = Field(
@@ -65,6 +67,8 @@ class ChargingHistoryEntry(CamelCaseModel):
         examples=[46.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Charging history entry")
+
 
 class ChargingHistoryResponse(CamelCaseModel):
     battery_charging_history: List[ChargingHistoryEntry] = Field(
@@ -79,9 +83,11 @@ class ChargingHistoryResponse(CamelCaseModel):
         examples=[1],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Charging history response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Charging history of a battery",
     description="Charging history of a battery.",

--- a/src/Energy/Battery/ProductDataSheet_v1.0.py
+++ b/src/Energy/Battery/ProductDataSheet_v1.0.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Set
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CellType(str, Enum):
@@ -92,8 +92,11 @@ class Voltage(CamelCaseModel):
         examples=[48.3],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Voltage")
+
 
 class Dimensions(CamelCaseModel):
+    # TODO: These should be floats
     length: int = Field(
         ...,
         title="Length [mm]",
@@ -109,6 +112,8 @@ class Dimensions(CamelCaseModel):
         title="Height [mm]",
         examples=[160],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Dimensions")
 
 
 class OperatingTemperature(CamelCaseModel):
@@ -130,8 +135,10 @@ class OperatingTemperature(CamelCaseModel):
     recommended_max: float = Field(
         ...,
         title="Maximum recommended operating temperature [°C]",
-        examples=[35],
+        examples=[35.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operating temperature")
 
 
 class BatteryDataRequest(CamelCaseModel):
@@ -141,6 +148,8 @@ class BatteryDataRequest(CamelCaseModel):
         description="The product code used by the manufacturer.",
         examples=["MPP48V"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Battery data request")
 
 
 class BatteryDataResponse(CamelCaseModel):
@@ -249,9 +258,11 @@ class BatteryDataResponse(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Battery data response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Battery product data sheet",
     description="Technical details of a battery such as capacity and voltage.",

--- a/src/Key/CreateAssignment_v1.0.py
+++ b/src/Key/CreateAssignment_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CreateAssignmentResponse(CamelCaseModel):
@@ -19,17 +19,21 @@ class CreateAssignmentResponse(CamelCaseModel):
         min_length=1,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Create assignment response")
+
 
 class CreateAssignmentRequest(CreateAssignmentResponse):
     shared_secret: str = Field(
         ...,
         title="Shared Secret",
-        description="Shared secret between the productizer and the system using it.",
+        description="Shared secret between the data source and the system using it.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Create assignment request")
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Create key assignment",
     description="Assign a key to have access to a specific lock.",

--- a/src/Key/DeleteAssignment_v1.0.py
+++ b/src/Key/DeleteAssignment_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class DeleteAssignmentResponse(CamelCaseModel):
@@ -19,17 +19,21 @@ class DeleteAssignmentResponse(CamelCaseModel):
         min_length=1,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Delete assignment response")
+
 
 class DeleteAssignmentRequest(DeleteAssignmentResponse):
     shared_secret: str = Field(
         ...,
         title="Shared Secret",
-        description="Shared secret between the productizer and the system using it.",
+        description="Shared secret between the data source and the system using it.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Delete assignment request")
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Delete key assignment",
     description="Remove a key from having access to a specific lock.",

--- a/src/Key/LockAssignmentExists_v1.0.py
+++ b/src/Key/LockAssignmentExists_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class LockAssignmentExistsRequest(CamelCaseModel):
@@ -21,8 +21,10 @@ class LockAssignmentExistsRequest(CamelCaseModel):
     shared_secret: str = Field(
         ...,
         title="Shared Secret",
-        description="Shared secret between the productizer and the system using it.",
+        description="Shared secret between the data source and the system using it.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Lock assignment exists request")
 
 
 class LockAssignmentExistsResponse(CamelCaseModel):
@@ -33,9 +35,11 @@ class LockAssignmentExistsResponse(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Lock assignment exists response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Check if lock assignment exists",
     description="Check if a key has access to a specific lock.",

--- a/src/Logistics/TransportChain/CarbonFootprint/Push_v0.1.py
+++ b/src/Logistics/TransportChain/CarbonFootprint/Push_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Literal, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -39,12 +39,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -92,7 +94,7 @@ class Request(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -131,6 +133,8 @@ class Request(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     status: Literal["ok"] = Field(
@@ -140,9 +144,11 @@ class Response(CamelCaseModel):
         examples=["ok"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Total carbon footprint for a transport chain",
     description="Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics"],

--- a/src/Logistics/TransportChain/CarbonFootprint_v0.1.py
+++ b/src/Logistics/TransportChain/CarbonFootprint_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -39,12 +39,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -62,6 +64,8 @@ class Request(CamelCaseModel):
         max_length=30,
         examples=["29771_01"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -95,7 +99,7 @@ class Response(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -134,9 +138,11 @@ class Response(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     title="Total carbon footprint for a transport chain",
     description="Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics"],

--- a/src/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.py
+++ b/src/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Location(CamelCaseModel):
@@ -24,12 +24,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class MonthlyFootprint(CamelCaseModel):
@@ -84,6 +86,8 @@ class MonthlyFootprint(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Monthly footprint")
+
 
 class Request(CamelCaseModel):
     id: str = Field(
@@ -102,6 +106,8 @@ class Request(CamelCaseModel):
         examples=["2025-08"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     monthly_footprints: list[MonthlyFootprint] = Field(
@@ -110,9 +116,11 @@ class Response(CamelCaseModel):
         description="A list of monthly carbon footprints for transport chains.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     title="Monthly carbon footprint for logistics transport chains",
     description="Monthly logistics carbon footprint for a cargo owner compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics", "Carbon footprint", "Emissions"],

--- a/src/Logistics/Transportation/TotalEmissions_v0.1.py
+++ b/src/Logistics/Transportation/TotalEmissions_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional, Set
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -30,10 +30,12 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -50,6 +52,8 @@ class Request(CamelCaseModel):
         max_length=30,
         examples=["29771_01"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -82,7 +86,7 @@ class Response(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -121,9 +125,11 @@ class Response(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     deprecated=True,
     title="Total emissions for a transport chain",

--- a/src/Market/Electricity/Pricing/History_v0.1.py
+++ b/src/Market/Electricity/Pricing/History_v0.1.py
@@ -2,20 +2,20 @@ import datetime
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EnergyPriceRequest(CamelCaseModel):
     location: str = Field(
         ...,
         title="Location",
-        description="E.g. the country in ISO 3166-1 alpha-3 or other location identifier.",
+        description="E.g. the country in ISO 3166-1 alpha-3 format or other location identifier.",
         examples=["FIN"],
     )
     start_time: datetime.datetime = Field(
         ...,
         title="Start time",
-        description="Start time of the requested time period, in RFC 3339.",
+        description="Start time of the requested time period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -31,7 +31,7 @@ class EnergyPriceRequest(CamelCaseModel):
     end_time: datetime.datetime = Field(
         ...,
         title="End time",
-        description="End time of the requested time period, in RFC 3339.",
+        description="End time of the requested time period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -45,6 +45,8 @@ class EnergyPriceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Energy price request")
+
 
 class PeriodPrice(CamelCaseModel):
     price: float = Field(
@@ -56,7 +58,7 @@ class PeriodPrice(CamelCaseModel):
     start_time: datetime.datetime = Field(
         ...,
         title="Start time",
-        description="Start time of the pricing period, in RFC 3339.",
+        description="Start time of the pricing period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -69,6 +71,8 @@ class PeriodPrice(CamelCaseModel):
             )
         ],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Period price")
 
 
 class EnergyPriceResponse(CamelCaseModel):
@@ -85,9 +89,11 @@ class EnergyPriceResponse(CamelCaseModel):
         description="List of the prices for the given time period.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Energy price response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Electricity market price",
     description="Electricity price per MWh.",

--- a/src/Meteorology/Weather_v0.1.py
+++ b/src/Meteorology/Weather_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class WeatherRequest(CamelCaseModel):
@@ -12,7 +12,7 @@ class WeatherRequest(CamelCaseModel):
         description="The latitude coordinate of the desired location in degrees.",
         ge=-90.0,
         le=90.0,
-        examples=[60.192059],
+        examples=[60.192],
     )
     lon: float = Field(
         ...,
@@ -20,7 +20,7 @@ class WeatherRequest(CamelCaseModel):
         description="The longitude coordinate of the desired location in degrees.",
         ge=-180.0,
         le=180.0,
-        examples=[24.945831],
+        examples=[24.945],
     )
     when: Optional[datetime.datetime] = Field(
         None,
@@ -30,6 +30,8 @@ class WeatherRequest(CamelCaseModel):
             datetime.datetime(2023, 4, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
         ],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Weather request")
 
 
 class WeatherResponse(CamelCaseModel):
@@ -46,14 +48,14 @@ class WeatherResponse(CamelCaseModel):
         description="Current relative air humidity percentage.",
         ge=0.0,
         le=100.0,
-        examples=[72],
+        examples=[72.0],
     )
     pressure: Optional[float] = Field(
         None,
         title="Pressure (hPa)",
         description="Current air pressure in hectopascals.",
         ge=0.0,
-        examples=[1007],
+        examples=[1007.0],
     )
     wind_speed: Optional[float] = Field(
         None,
@@ -87,9 +89,11 @@ class WeatherResponse(CamelCaseModel):
         examples=[320.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Weather response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Weather in metric units",
     description="Weather information for a given location, either current "

--- a/src/NSG/Agent/BasicInformation_v1.0.py
+++ b/src/NSG/Agent/BasicInformation_v1.0.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class BasicInformationRequest(CamelCaseModel):
@@ -13,6 +13,8 @@ class BasicInformationRequest(CamelCaseModel):
         description="National identifier for a legal entity.",
         examples=["2464491-9"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Basic information request")
 
 
 class NordicLegalForm(str, Enum):
@@ -509,7 +511,7 @@ class RegisteredAddress(CamelCaseModel):
     )
     address_id: Optional[str] = Field(
         None,
-        title="Address id",
+        title="Address ID",
         description="A globally unique identifier for each instance of an Address. The "
         "concept of adding a globally unique identifier for each instance of an "
         "address is a crucial part of the INSPIRE data spec. A number of EU countries "
@@ -519,6 +521,8 @@ class RegisteredAddress(CamelCaseModel):
         min_length=1,
         max_length=40,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Registered address")
 
 
 class BasicInformationResponse(CamelCaseModel):
@@ -549,9 +553,11 @@ class BasicInformationResponse(CamelCaseModel):
     )
     registered_address: RegisteredAddress
 
+    model_config: ConfigDict = ConfigDict(title="Basic information response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="NSG Agent information",
     description="In the Nordic Smart Government information exchange context the agent "

--- a/src/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners_v1.0.py
+++ b/src/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners_v1.0.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ShareOwnership(CamelCaseModel):
@@ -18,6 +18,8 @@ class ShareOwnership(CamelCaseModel):
         description="The number of shares that the shareholder owns a share series.",
         examples=[20],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Share ownership")
 
 
 class ShareSeries(CamelCaseModel):
@@ -41,13 +43,15 @@ class ShareSeries(CamelCaseModel):
         examples=[1],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Share series")
+
 
 class Shareholder(CamelCaseModel):
     name: str = Field(
         ...,
         title="Name",
         description="The name of a shareholder of the company.",
-        examples=["Lars Lindberg | Company Ltd"],
+        examples=["Lars Lindberg", "Company Ltd"],
         max_length=250,
     )
     share_ownership: List[ShareOwnership] = Field(
@@ -56,6 +60,8 @@ class Shareholder(CamelCaseModel):
         description="The list of ownerships that the shareholder has in the company.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Shareholder")
+
 
 class BeneficialOwnersRequest(CamelCaseModel):
     national_identifier: str = Field(
@@ -63,9 +69,11 @@ class BeneficialOwnersRequest(CamelCaseModel):
         title="National identifier",
         description="The national identifier of the non-listed company issued by the "
         "trade register in any Nordic country.",
-        examples=["FIN: 2464491-9 / SWE: 5560125791 / NOR:  923609016"],
+        examples=["2464491-9", "5560125791", "923609016"],
         max_length=40,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Beneficial owners request")
 
 
 class BeneficialOwnersResponse(CamelCaseModel):
@@ -80,9 +88,11 @@ class BeneficialOwnersResponse(CamelCaseModel):
         description="The list of beneficial owners of the company.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Beneficial owners response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     deprecated=True,
     title="Beneficial owners of a non-listed company",

--- a/src/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write_v1.0.py
+++ b/src/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write_v1.0.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class IndustrySector(str, Enum):
@@ -1269,7 +1269,7 @@ class Registrant(CamelCaseModel):
         ...,
         title="Email",
         description="The person's contact email address.",
-        examples=["john.doe@test.fi"],
+        examples=["john.doe@example.com"],
     )
     phone_number: str = Field(
         ...,
@@ -1278,6 +1278,8 @@ class Registrant(CamelCaseModel):
         examples=["+358501234567"],
         max_length=250,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Registrant")
 
 
 class CompanyDetails(CamelCaseModel):
@@ -1346,10 +1348,11 @@ class CompanyDetails(CamelCaseModel):
     country_of_residence: Optional[ISO_3166_1_Alpha_3] = Field(
         None,
         title="Country of residence",
-        description="The company's current country of the residence in the three "
-        "character (Alpha-3) format if it already exists abroad.",
+        description="The company's current country of the residence in the ISO 3166-1 alpha-3 format if it already exists abroad.",
         examples=[ISO_3166_1_Alpha_3.USA],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Company details")
 
 
 class ShareSeries(CamelCaseModel):
@@ -1378,6 +1381,8 @@ class ShareSeries(CamelCaseModel):
         description="The currency used for the share value in ISO 4217 format.",
         examples=[ISO_4217_CurrencyCode.EUR],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Share series")
 
 
 class CompanyAddress(CamelCaseModel):
@@ -1473,6 +1478,8 @@ class CompanyAddress(CamelCaseModel):
         max_length=40,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Company address")
+
 
 class ManagingDirector(CamelCaseModel):
     role: ManagingDirectorRole = Field(
@@ -1514,6 +1521,8 @@ class ManagingDirector(CamelCaseModel):
         description="The nationality of the person.",
         examples=[ISO_3166_1_Alpha_3.USA],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Managing director")
 
 
 class BoardMember(CamelCaseModel):
@@ -1557,6 +1566,8 @@ class BoardMember(CamelCaseModel):
         examples=[ISO_3166_1_Alpha_3.USA],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Board member")
+
 
 class AuditorDetails(CamelCaseModel):
     company_name: Optional[str] = Field(
@@ -1588,6 +1599,8 @@ class AuditorDetails(CamelCaseModel):
         examples=["Doe"],
         max_length=250,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Auditor details")
 
 
 class EstablishmentRequest(CamelCaseModel):
@@ -1625,13 +1638,15 @@ class EstablishmentRequest(CamelCaseModel):
         description="The details of the company and person auditing the company.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Establishment request")
+
 
 class EstablishmentResponse(EstablishmentRequest):
     pass
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     deprecated=True,
     title="Establish a non-listed company",

--- a/src/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights_v1.0.py
+++ b/src/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights_v1.0.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ISO_3166_1_Alpha_3(str, Enum):
@@ -310,7 +310,6 @@ class SignatoryRights(CamelCaseModel):
         description="The nationality of a person.",
         examples=[ISO_3166_1_Alpha_3.USA],
     )
-
     full_address: Optional[str] = Field(
         None,
         title="Full address",
@@ -320,7 +319,6 @@ class SignatoryRights(CamelCaseModel):
         examples=["Tietotie 4 A 7, 00100 Helsinki, Finland"],
         max_length=250,
     )
-
     thoroughfare: Optional[str] = Field(
         None,
         title="Thoroughfare",
@@ -403,6 +401,8 @@ class SignatoryRights(CamelCaseModel):
         max_length=40,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Signatory rights")
+
 
 class SignatoryRightsRequest(CamelCaseModel):
     national_identifier: str = Field(
@@ -410,9 +410,11 @@ class SignatoryRightsRequest(CamelCaseModel):
         title="National identifier",
         description="The national identifier of the non-listed company issued by the "
         "trade register.",
-        examples=["FIN: 2464491-9 / SWE: 5560125791 / NOR: 923609016"],
+        examples=["2464491-9", "5560125791", "923609016"],
         max_length=40,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Signatory rights request")
 
 
 class SignatoryRightsResponse(CamelCaseModel):
@@ -423,9 +425,11 @@ class SignatoryRightsResponse(CamelCaseModel):
         "company.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Signatory rights response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     deprecated=True,
     title="Signatory rights of a non-listed company",

--- a/src/Person/Details_v1.0.py
+++ b/src/Person/Details_v1.0.py
@@ -1,9 +1,9 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class PersonDetailsRequest(CamelCaseModel):
-    pass
+    model_config: ConfigDict = ConfigDict(title="Person details request")
 
 
 class PersonDetailsResponse(CamelCaseModel):
@@ -20,9 +20,11 @@ class PersonDetailsResponse(CamelCaseModel):
         examples=["6 Raymond river\nRileybury\nCR3 6XA"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Person details response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     deprecated=True,
     title="Person details",

--- a/src/Product/MachinedComponent/MeasurementReport_v0.1.py
+++ b/src/Product/MachinedComponent/MeasurementReport_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class MeasurementEquipment(CamelCaseModel):
@@ -28,11 +28,13 @@ class MeasurementEquipment(CamelCaseModel):
         examples=["mp-001-rv02"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement equipment")
+
 
 class ComponentIdentification(CamelCaseModel):
     purchase_order: str = Field(
         ...,
-        title="Purchase order ",
+        title="Purchase order",
         description="The number of the purchase order related to the component.",
         max_length=40,
         examples=["12345"],
@@ -52,6 +54,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["pn-20240205-00123"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class CustomerInformation(CamelCaseModel):
     name: str = Field(
@@ -59,15 +63,17 @@ class CustomerInformation(CamelCaseModel):
         title="Name",
         description="The name of the customer that has issued the component order.",
         max_length=250,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     department: Optional[str] = Field(
         None,
         title="Department",
         description="The responsible department of the customer that has issued the component order.",
         max_length=250,
-        examples=["Department xyz"],
+        examples=["Department Name"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Customer information")
 
 
 class MeasurementSetup(CamelCaseModel):
@@ -130,6 +136,8 @@ class MeasurementSetup(CamelCaseModel):
         description="The identifiers of the equipment used in the measuring of the component.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement setup")
+
 
 class MeasurementResult(CamelCaseModel):
     feature_name: str = Field(
@@ -176,6 +184,8 @@ class MeasurementResult(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement result")
+
 
 class Request(CamelCaseModel):
     id: str = Field(
@@ -185,6 +195,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["b1a-0723y-00165"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -209,9 +221,11 @@ class Response(CamelCaseModel):
         description="The results of the quality measurements.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     deprecated=True,
     title="Machined component measurement report",

--- a/src/Product/Manufacturing/EnvironmentalFootprint_v1.0.py
+++ b/src/Product/Manufacturing/EnvironmentalFootprint_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EnvironmentalFootprintRequest(CamelCaseModel):
@@ -9,6 +9,8 @@ class EnvironmentalFootprintRequest(CamelCaseModel):
         description="The serial number given by the manufacturer.",
         examples=["MPP48V-296cde7f"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Environmental footprint request")
 
 
 class EnvironmentalFootprintResponse(CamelCaseModel):
@@ -25,9 +27,11 @@ class EnvironmentalFootprintResponse(CamelCaseModel):
         examples=[8.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Environmental footprint response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Environmental footprint information for a product",
     description="Information about environmental footprint of a product in the manufacturing phase.",

--- a/src/Product/MetalComponent/MeasurementReport_v0.3.py
+++ b/src/Product/MetalComponent/MeasurementReport_v0.3.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -46,6 +46,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["xy00012345687"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class CustomerInformation(CamelCaseModel):
     name: Optional[str] = Field(
@@ -54,7 +56,7 @@ class CustomerInformation(CamelCaseModel):
         description="The name of the customer that has issued the component order.",
         min_length=0,
         max_length=250,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     department: Optional[str] = Field(
         None,
@@ -62,8 +64,10 @@ class CustomerInformation(CamelCaseModel):
         description="The responsible department of the customer that has issued the component order.",
         min_length=0,
         max_length=250,
-        examples=["Department xyz"],
+        examples=["Department Name"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Customer information")
 
 
 class MeasurementResult(CamelCaseModel):
@@ -112,6 +116,8 @@ class MeasurementResult(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement result")
+
 
 class MeasurementEquipment(CamelCaseModel):
     machine_serial_number: Optional[str] = Field(
@@ -122,6 +128,8 @@ class MeasurementEquipment(CamelCaseModel):
         max_length=40,
         examples=["mfg-model-xxxx-yyyy"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Measurement equipment")
 
 
 class MeasurementSetup(CamelCaseModel):
@@ -160,7 +168,7 @@ class MeasurementSetup(CamelCaseModel):
     batch_size: Optional[int] = Field(
         None,
         title="Batch size",
-        description="The entire size of the batch that was manufactured under the same id.",
+        description="The entire size of the batch that was manufactured under the same ID.",
         examples=[100],
     )
     measured_items: Optional[int] = Field(
@@ -185,6 +193,8 @@ class MeasurementSetup(CamelCaseModel):
         title="Measurement equipment",
         description="The identifiers of the equipment used to measure the component.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Measurement setup")
 
 
 class Request(CamelCaseModel):
@@ -211,6 +221,8 @@ class Request(CamelCaseModel):
         examples=["batch-12345"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     component_identification: ComponentIdentification = Field(
@@ -234,9 +246,11 @@ class Response(CamelCaseModel):
         description="The results of the quality measurements.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.2",
+    version="0.3.3",
     strict_validation=False,
     title="Metal component measurement report",
     description="The quality measurement report for metal components.",

--- a/src/Product/MetalComponent/Traceability_v0.3.py
+++ b/src/Product/MetalComponent/Traceability_v0.3.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -17,7 +17,7 @@ class CompanyIdentifierScheme(str, Enum):
     DUNS = "duns"
 
 
-class SubComponent(CamelCaseModel):
+class Subcomponent(CamelCaseModel):
     name: Optional[str] = Field(
         None,
         title="Name",
@@ -34,6 +34,8 @@ class SubComponent(CamelCaseModel):
         max_length=20,
         examples=["batch-2024-ssbolt-0037"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Subcomponent")
 
 
 class Blank(CamelCaseModel):
@@ -54,6 +56,8 @@ class Blank(CamelCaseModel):
         examples=["forging billet"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Blank")
+
 
 class CompanyIdentification(CamelCaseModel):
     identifier_scheme: Optional[CompanyIdentifierScheme] = Field(
@@ -71,6 +75,8 @@ class CompanyIdentification(CamelCaseModel):
         examples=["1234567890123"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Company identification")
+
 
 class ProcessIdentification(CamelCaseModel):
     identifier: Optional[str] = Field(
@@ -82,6 +88,8 @@ class ProcessIdentification(CamelCaseModel):
         examples=["procset-metal-2024-0458"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Process identification")
+
 
 class ComponentIdentification(CamelCaseModel):
     name: Optional[str] = Field(
@@ -91,9 +99,10 @@ class ComponentIdentification(CamelCaseModel):
         min_length=0,
         max_length=150,
     )
-    sub_component_declaration: list[SubComponent] = Field(
+    # TODO: subcomponent_declaration
+    sub_component_declaration: list[Subcomponent] = Field(
         ...,
-        title="Sub component declaration",
+        title="Subcomponent declaration",
         description="List of declared subcomponents used in the component assembly.",
     )
     purchase_order: Optional[str] = Field(
@@ -150,6 +159,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["Rev A"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class ManufacturerInformation(CamelCaseModel):
     name: Optional[str] = Field(
@@ -158,7 +169,7 @@ class ManufacturerInformation(CamelCaseModel):
         description="The registered trade name of the manufacturer company.",
         min_length=0,
         max_length=40,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     identification: CompanyIdentification = Field(
         ...,
@@ -179,8 +190,10 @@ class ManufacturerInformation(CamelCaseModel):
         description="The designated email contact for inquiries related to component manufacturing.",
         min_length=0,
         max_length=40,
-        examples=["contact@company.com"],
+        examples=["contact@example.com"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class Request(CamelCaseModel):
@@ -206,6 +219,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["batch-12345"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -237,9 +252,11 @@ class Response(CamelCaseModel):
         description=None,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.3",
+    version="0.3.4",
     strict_validation=False,
     title="Metal component traceability information",
     description="The traceability information of a metal component.",

--- a/src/Product/Sustainability/CarbonFootprint_v0.1.py
+++ b/src/Product/Sustainability/CarbonFootprint_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -33,6 +33,8 @@ class Request(CamelCaseModel):
         examples=["batch-12345"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     material_footprint: Optional[float] = Field(
@@ -50,13 +52,15 @@ class Response(CamelCaseModel):
     logistics_footprint: Optional[float] = Field(
         None,
         title="Logistics footprint (kg of CO2e)",
-        description="The carbon footprint generated from the upstream logisitics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
+        description="The carbon footprint generated from the upstream logistics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
         examples=[0.3],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Product carbon footprint",
     description="The carbon footprint of manufacturing a product.",

--- a/src/TimeAndDate/CurrentTime_v1.0.py
+++ b/src/TimeAndDate/CurrentTime_v1.0.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Country(str, Enum):
@@ -260,15 +260,19 @@ class Country(str, Enum):
 class CurrentTimeRequest(CamelCaseModel):
     country_code: Country = Field(title="ISO 3166-1 alpha-2 country code")
 
+    model_config: ConfigDict = ConfigDict(title="Current time request")
+
 
 class CurrentTimeResponse(CamelCaseModel):
     current_time: str = Field(
         title="Current time in the desired country in RFC 3339 format"
     )
 
+    model_config: ConfigDict = ConfigDict(title="Current time response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Current time in a given country",
     description="Get the current time in a given country based on the ISO 3166-1 alpha-2 country code, formatted in RFC 3339 format.",

--- a/src/Transport/Vehicle/Emissions_v0.1.py
+++ b/src/Transport/Vehicle/Emissions_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EmissionsRequest(CamelCaseModel):
@@ -26,6 +26,8 @@ class EmissionsRequest(CamelCaseModel):
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Emissions request")
+
 
 class EmissionsResponse(CamelCaseModel):
     start_time: Optional[datetime] = Field(
@@ -44,7 +46,7 @@ class EmissionsResponse(CamelCaseModel):
         ...,
         title="Carbon dioxide (kg)",
         description="The mass of the carbon dioxide (CO2) emissions in kilograms.",
-        examples=[4000],
+        examples=[4000.0],
     )
     nitrogen_oxides: float = Field(
         ...,
@@ -59,9 +61,11 @@ class EmissionsResponse(CamelCaseModel):
         examples=[0.05],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Emissions response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Transport vehicle emissions",
     description="The emissions of a transport vehicle.",

--- a/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
+++ b/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EstimatedArrival(CamelCaseModel):
@@ -42,6 +42,8 @@ class EstimatedArrival(CamelCaseModel):
         examples=[["DGT1234567", "FTP7654321"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Estimated arrival")
+
 
 class Request(CamelCaseModel):
     location_id: str = Field(
@@ -65,6 +67,8 @@ class Request(CamelCaseModel):
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     estimated_arrivals: list[EstimatedArrival] = Field(
@@ -73,9 +77,11 @@ class Response(CamelCaseModel):
         description="Estimated arrival times.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Estimated arrival times",
     description="Estimated arrival times of vehicles within a transport location.",

--- a/src/Transport/Vehicle/OperationalPerformance_v0.1.py
+++ b/src/Transport/Vehicle/OperationalPerformance_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class OperationalPerformanceRequest(CamelCaseModel):
@@ -25,6 +25,8 @@ class OperationalPerformanceRequest(CamelCaseModel):
         description="The end time of the performance period in, RFC 3339 format.",
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -77,9 +79,11 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[50.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Transport vehicle operational performance",
     description="General operational performance data of a transport vehicle.",

--- a/src/Transport/Vehicle/OperationalStatus_v0.1.py
+++ b/src/Transport/Vehicle/OperationalStatus_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Location(CamelCaseModel):
@@ -12,7 +12,7 @@ class Location(CamelCaseModel):
         description="The latitude coordinate in decimal degrees.",
         gte=-90,
         lte=90,
-        examples=[60.192059],
+        examples=[60.192],
     )
     longitude: float = Field(
         ...,
@@ -20,8 +20,10 @@ class Location(CamelCaseModel):
         description="The longitude coordinate in decimal degrees.",
         gte=-180,
         lte=180,
-        examples=[24.945831],
+        examples=[24.945],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class OperationalStatusRequest(CamelCaseModel):
@@ -38,6 +40,8 @@ class OperationalStatusRequest(CamelCaseModel):
         description="Request the vehicle's status information at or before this given time, in RFC 3339 format. If empty, provide latest value.",
         examples=[datetime.fromisoformat("2023-04-12T23:20:50Z")],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operational status request")
 
 
 class OperationalStatusResponse(CamelCaseModel):
@@ -75,9 +79,11 @@ class OperationalStatusResponse(CamelCaseModel):
         description="The location in GPS coordinates.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Transport vehicle operational status",
     description="General operational status data of a transport vehicle.",

--- a/src/Transport/Vehicle/TurnaroundTimes_v0.3.py
+++ b/src/Transport/Vehicle/TurnaroundTimes_v0.3.py
@@ -2,7 +2,7 @@ import datetime
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class TurnaroundTime(CamelCaseModel):
@@ -44,6 +44,8 @@ class TurnaroundTime(CamelCaseModel):
         examples=[3600],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time")
+
 
 class TurnaroundTimeRequest(CamelCaseModel):
     location_id: str = Field(
@@ -73,6 +75,8 @@ class TurnaroundTimeRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time request")
+
 
 class TurnaroundTimeResponse(CamelCaseModel):
     turnaround_times: List[TurnaroundTime] = Field(
@@ -81,9 +85,11 @@ class TurnaroundTimeResponse(CamelCaseModel):
         description="The list of turnaround times of vehicles within the facility.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.2",
+    version="0.3.3",
     strict_validation=False,
     title="Vehicle turnaround times",
     description="Turnaround times of vehicles within a facility.",

--- a/src/Weather/Current/Metric_v1.0.py
+++ b/src/Weather/Current/Metric_v1.0.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CurrentWeatherMetricRequest(CamelCaseModel):
@@ -9,7 +9,7 @@ class CurrentWeatherMetricRequest(CamelCaseModel):
         description="The latitude coordinate of the desired location.",
         ge=-90.0,
         le=90.0,
-        examples=[60.192059],
+        examples=[60.192],
     )
     lon: float = Field(
         ...,
@@ -17,8 +17,10 @@ class CurrentWeatherMetricRequest(CamelCaseModel):
         description="The longitude coordinate of the desired location.",
         ge=-180.0,
         le=180.0,
-        examples=[24.945831],
+        examples=[24.945],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Current weather metric request")
 
 
 class CurrentWeatherMetricResponse(CamelCaseModel):
@@ -26,9 +28,9 @@ class CurrentWeatherMetricResponse(CamelCaseModel):
         ...,
         title="Current relative air humidity (%)",
         description="Current relative air humidity in percentages.",
-        examples=[72],
+        examples=[72.0],
     )
-    pressure: float = Field(..., title="Current air pressure in hPa", examples=[1007])
+    pressure: float = Field(..., title="Current air pressure in hPa", examples=[1007.0])
     rain: bool = Field(
         ..., title="Rain status", description="If it's currently raining or not."
     )
@@ -55,9 +57,11 @@ class CurrentWeatherMetricResponse(CamelCaseModel):
         examples=[220.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Current weather metric response")
+
 
 DEFINITION = DataProductDefinition(
-    version="1.0.3",
+    version="1.0.4",
     strict_validation=False,
     title="Current weather in a given location",
     description="Common data points about the current weather with metric units in a given location. Simplified for example use, and not following industry standards.",

--- a/src/test/Indoor/BLEBeacons.py
+++ b/src/test/Indoor/BLEBeacons.py
@@ -15,7 +15,7 @@ class Beacon(CamelCaseModel):
         ...,
         title="RSSI",
         description="Received Signal Strength Indication, in dBm",
-        examples=[-55],
+        examples=[-55.0],
     )
 
 

--- a/src/test/LetterOfCredit/ExportInstructions.py
+++ b/src/test/LetterOfCredit/ExportInstructions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ExportInstructionsResponse(CamelCaseModel):

--- a/src/test/Product/DimensionsAndWeights.py
+++ b/src/test/Product/DimensionsAndWeights.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class DimensionsAndWeightsResponse(CamelCaseModel):

--- a/src/test/Shipment/ForwardersCargoReceipt.py
+++ b/src/test/Shipment/ForwardersCargoReceipt.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ForwardersCargoReceiptResponse(CamelCaseModel):

--- a/src/test/Shipment/InsuranceCertificate.py
+++ b/src/test/Shipment/InsuranceCertificate.py
@@ -1,5 +1,5 @@
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class InsuranceCertificateResponse(CamelCaseModel):

--- a/src/test/Shipment/PackingList.py
+++ b/src/test/Shipment/PackingList.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class ProductItem(CamelCaseModel):

--- a/src/test/Transaction/Invoice.py
+++ b/src/test/Transaction/Invoice.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class InvoiceResponse(CamelCaseModel):

--- a/src/test/ioxio-dataspace-guides/Country/BasicInfo.py
+++ b/src/test/ioxio-dataspace-guides/Country/BasicInfo.py
@@ -20,24 +20,24 @@ class Capital(CamelCaseModel):
     name: str = Field(
         ...,
         title="Name",
-        description="The name of the capital of the Country",
+        description="The name of the capital of the country",
         examples=["Helsinki"],
     )
     lat: float = Field(
         ...,
         title="Latitude",
-        description="The latitude coordinate of the Capital",
+        description="The latitude coordinate of the capital",
         ge=-90.0,
         le=90.0,
-        examples=[60.170833],
+        examples=[60.170],
     )
     lon: float = Field(
         ...,
         title="Longitude",
-        description="The longitude coordinate of the Capital",
+        description="The longitude coordinate of the capital",
         ge=-180.0,
         le=180.0,
-        examples=[24.9375],
+        examples=[24.937],
     )
 
 
@@ -60,7 +60,7 @@ class BasicCountryInfoResponse(CamelCaseModel):
         ...,
         title="Area",
         description="The area of the country in km^2",
-        examples=[338455],
+        examples=[338455.0],
     )
     languages: List[Annotated[str, StringConstraints(min_length=2, max_length=2)]] = (
         Field(


### PR DESCRIPTION
Fixed common formatting and consistency issues.

- Using consistent naming for ISO 3166-1 alpha-2/3
- "RFC 3339 format" instead of just "RFC 3339"
- Float examples for float fields
- Company xyz -> Example LLC etc.
- company.com -> example.com
- Adding sensible titles to models.
- Updating patch version numbers of affected files
- Cleaned up extra spaces
- Fixed spelling errors
- Removed unnecessary level of detail from coordinates